### PR TITLE
Nomad Integration with Vault

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "modules/core/packer/roles/ansible-docker-ubuntu"]
 	path = modules/core/packer/roles/ansible-docker-ubuntu
 	url = https://github.com/lawliet89/ansible-docker-ubuntu.git
+[submodule "modules/core/packer/roles/ansible-ca-store"]
+	path = modules/core/packer/roles/ansible-ca-store
+	url = https://github.com/lawliet89/ansible-ca-store.git

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -63,10 +63,6 @@ You will need to generate the following certificates:
 
 Refer to instructions [here](ca/README.md).
 
-By default, the following paths are assumed while building the AMIs:
-
-__TODO__: Fill this up!
-
 ### Preparing Secrets
 
 #### Consul Gossip Encryption
@@ -100,9 +96,6 @@ to specify AWS credentials.
 Refer to each of the directories for instruction.
 
 Take note of the AMI IDs returned from this.
-
-__TODO__: Differentiate between initial "bootstrap" variables in Packer templates and post
-"bootstrap" variables. Also, deal with "common" variable files.
 
 ## Defining Variables
 

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -315,7 +315,7 @@ aws autoscaling update-auto-scaling-group \
     --desired-capacity xxx
 ```
 
-Wait for the new nodes to be ready and first before you continue.
+Wait for the new nodes to be ready before you continue.
 
 4. Find the Nomad node IDs for each instance. Assuming you have saved the instance IDs to `instance-ids.txt` and that you have kept the default configuration where the node name is the instance ID:
 

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -332,7 +332,7 @@ while read p; do
 done < instance-ids.txt
 ```
 
-4. Set the instances you are going to retire as
+5. Set the instances you are going to retire as
 ["ineligible"](https://www.nomadproject.io/docs/commands/node/eligibility.html) in Nomad. For example, assuming you have saved the instance IDs to `node-ids.txt`:
 
 ```bash
@@ -341,7 +341,7 @@ while read p; do
 done < node-ids.txt
 ```
 
-5. Detach the instances from the ASG and wait for the ELB connections to drain. **Make sure you wait for the connections to completely drain first before continuing.** For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+6. Detach the instances from the ASG and wait for the ELB connections to drain. **Make sure you wait for the connections to completely drain first before continuing.** For example, assuming you have saved the instance IDs to `instance-ids.txt`:
 
 ```bash
 aws autoscaling detach-instances \
@@ -364,7 +364,7 @@ done; \
 echo "Done"
 ```
 
-6. [Drain](https://www.nomadproject.io/docs/commands/node/drain.html) the clients. For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+7. [Drain](https://www.nomadproject.io/docs/commands/node/drain.html) the clients. For example, assuming you have saved the instance IDs to `instance-ids.txt`:
 
 ```bash
 while read p; do
@@ -372,7 +372,7 @@ while read p; do
 done < instance-ids.txt
 ```
 
-7. After the allocations are drained, terminate the instances.  For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+8. After the allocations are drained, terminate the instances.  For example, assuming you have saved the instance IDs to `instance-ids.txt`:
 
 ```bash
 aws ec2 terminate-instances \

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -328,7 +328,7 @@ done < instance-ids.txt
 ```
 
 5. Set the instances you are going to retire as
-["ineligible"](https://www.nomadproject.io/docs/commands/node/eligibility.html) in Nomad. For example, assuming you have saved the instance IDs to `node-ids.txt`:
+["ineligible"](https://www.nomadproject.io/docs/commands/node/eligibility.html) in Nomad. For example, assuming you have saved the node IDs to `node-ids.txt`:
 
 ```bash
 while read p; do
@@ -336,10 +336,17 @@ while read p; do
 done < node-ids.txt
 ```
 
-6. Detach the instances from the ASG and wait for the ELB connections to drain. **Make sure you wait for the connections to completely drain first before continuing.** For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+6. The following has to be done **one instance at a time**. Detach the instance from the ASG and wait for the ELB connections to drain. **Make sure you wait for the connections to completely drain first before continuing.** Then, [drain](https://www.nomadproject.io/docs/commands/node/drain.html) the clients.
+
+<!-- FIXME: We should not be doing all these on all the instances at one go. Fix this section by
+writing and testing a new script. Previous version left for posterity for now.-->
+
+<!-- For example, assuming you have saved the instance IDs to `instance-ids.txt` and node IDs to
+`node-ids.txt:
 
 ```bash
 aws autoscaling detach-instances \
+    --auto-scaling-group-name ASGName \
     --instance-ids $(cat instance-ids.txt | tr '\n' ' ') \
     --should-decrement-desired-capacity
 ```
@@ -359,15 +366,13 @@ done; \
 echo "Done"
 ```
 
-7. [Drain](https://www.nomadproject.io/docs/commands/node/drain.html) the clients. For example, assuming you have saved the instance IDs to `instance-ids.txt`:
-
 ```bash
 while read p; do
   nomad node drain -enable "${p}"
-done < instance-ids.txt
-```
+done < node-ids.txt
+``` -->
 
-8. After the allocations are drained, terminate the instances.  For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+7. After the allocations are drained, terminate the instances.  For example, assuming you have saved the instance IDs to `instance-ids.txt`:
 
 ```bash
 aws ec2 terminate-instances \

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -16,9 +16,8 @@ After the initial bootstrap, you will need to perform additional configuration f
 hardening. In particular, you will have to initialise Vault and configure Vault before you can use
 it for anything.
 
-After you have done that, you can tweak your Packer variables accordingly to harden your clusters
-by making use of Vault. This cannot be done at the initial bootstrap because Vault is not
-initialised yet. They are documented in a later section.
+You can use the other companion Terraform modules in this repository to perform some of the
+configuration. They are documented briefly below, and in more detail in their own directories.
 
 ## Requirements
 
@@ -231,10 +230,24 @@ To generate an inventory for the playbooks, you can run
 ./vault-helper.sh -i > inventory
 ```
 
-### Upgrading
+### Vault Integration with Nomad
+
+Nomad can be [integrated](https://www.nomadproject.io/docs/vault-integration/index.html) with Vault
+so that jobs can transparently retrieve tokens from Vault.
+
+After you have initialised and unsealed Vault, you can use the
+[`nomad-vault-integration`](../nomad-vault-integration) module to Terraform the required policies
+and settings for Vault.
+
+The default `user_data` scripts for Nomad servers and clients will automatically detect that the
+policies have been setup and will configure themselves correctly. To update your cluster to use
+the new Vault integration, simply follow the section below to update the Nomad servers first and
+then the clients.
+
+### Upgrading and updating
 
 In general, to upgrade or update the servers, you will have to update the packer template file,
-build a new AMI, the update the terraform variables with the new AMI ID. Then, you can run
+build a new AMI, then update the terraform variables with the new AMI ID. Then, you can run
 `terraform apply` to update the launch configuration.
 
 Then, you will need to terminate the various instances for Auto Scaling Group to start
@@ -242,6 +255,12 @@ new instances with the updated launch configurations. You should do this ONE BY 
 
 #### Upgrading Consul
 
+**Important**: It is important that you only terminate Consul instances one by one. Make sure the
+new servers are healthy and have joined the cluster before continuing. If you lose more than a
+quorum of servers, you might have data loss and have to perform
+[outage recovery](https://www.consul.io/docs/guides/outage.html).
+
+1. Build your new AMI, and Terraform apply the new AMI.
 1. Terminate the instance that you would like to remove.
 1. The Consul server will gracefully exit, and cause the node to become unhealthy, and AWS will automatically start a new instance.
 
@@ -258,6 +277,12 @@ Replace `xxx` with the instance ID.
 
 #### Upgrading Nomad Servers
 
+**Important**: It is important that you only terminate Nomad server instances one by one.
+ Make sure the new servers are healthy and have joined the cluster before continuing.
+If you lose more than a quorum of servers, you might have data loss and have to perform
+[outage recovery](https://www.nomadproject.io/guides/outage.html).
+
+1. Build your new AMI, and Terraform apply the new AMI.
 1. Terminate the instance that you would like to remove.
 1. The nomad server will gracefully exit, and cause the node to become unhealthy, and AWS will automatically start a new instance.
 
@@ -274,22 +299,85 @@ Replace `xxx` with the instance ID.
 
 #### Upgrading Nomad Clients
 
-When draining Nomad client nodes, users will experience momentary downtime as ELB catches up with
-the unhealthy client status.
+**Important**: These steps are recommended to minimise the outage your services might experience. In particular,
+if you service only has one instance of it running, you will definitely encounter outage. Ensure
+that your services have at least two instances running.
 
-1. Drain the servers using `nomad node-drain node-id`
-1. After the allocations are drained, terminate the instance and AWS will launch a new instance.
-
-You can use this AWS CLI command:
+1. Build your new AMI, and Terraform apply the new AMI.
+2. Take note of the old instances ID that you are going to retiring. You can get a list of the instance IDs with the command:
 
 ```bash
-aws autoscaling \
-    terminate-instance-in-auto-scaling-group \
-    --no-should-decrement-desired-capacity \
-    --instance-id "xxx"
+aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-name ASGName \
+    | jq --raw-output '.AutoScalingGroups[0].Instances[].InstanceId' \
+    | tee instance-ids.txt
 ```
 
-Replace `xxx` with the instance ID.
+3. Using Terraform or the AWS console, set the `desired` capacity of your auto-scaling group to twice the current desired value. Make sure the `maximum` is set to a high enough value so that you set the appropriate `desired` value. This is spin up new clients that will be prepared to take over from the instances you are retiring. Alternatively, you can use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/update-auto-scaling-group.html) too:
+
+```bash
+aws autoscaling update-auto-scaling-group \
+    --auto-scaling-group-name ASGName \
+    --max-size xxx \
+    --desired-capacity xxx
+```
+
+4. Find the Nomad node IDs for each instance. Assuming you have saved the instance IDs to `instance-ids.txt` and that you have kept the default configuration where the node name is the instance ID:
+
+```bash
+nomad node status -json > nodes.json
+echo -n "" > node-ids.txt
+while read p; do
+    jq --raw-output ".[] | select (.Name == \"${p}\") | .ID" nodes.json  >> node-ids.txt
+done < instance-ids.txt
+```
+
+4. Set the instances you are going to retire as
+["ineligible"](https://www.nomadproject.io/docs/commands/node/eligibility.html) in Nomad. For example, assuming you have saved the instance IDs to `node-ids.txt`:
+
+```bash
+while read p; do
+  nomad node eligibility -disable "${p}"
+done < node-ids.txt
+```
+
+5. Detach the instances from the ASG and wait for the ELB connections to drain. **Make sure you wait for the connections to completely drain first before continuing.** For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+
+```bash
+aws autoscaling detach-instances \
+    --instance-ids $(cat instance-ids.txt | tr '\n' ' ') \
+    --should-decrement-desired-capacity
+```
+
+You can monitor the connection draining in the AWS Console or you can use this command repeatedly
+until all the instances are no longer associated with the ASG and the count returns zero:
+
+```bash
+COUNT="999";
+while [[ "${COUNT}" != "0" ]]; do \
+    COUNT=$(aws autoscaling describe-auto-scaling-instances \
+    --instance-ids $(cat instance-ids.txt | tr '\n' ' ') \
+    | jq '.AutoScalingInstances | length'); \
+    echo "Still ${COUNT} instances. Retrying in 5 seconds"; \
+    sleep 5; \
+done; \
+echo "Done"
+```
+
+6. [Drain](https://www.nomadproject.io/docs/commands/node/drain.html) the clients. For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+
+```bash
+while read p; do
+  nomad node drain -enable "${p}"
+done < instance-ids.txt
+```
+
+7. After the allocations are drained, terminate the instances.  For example, assuming you have saved the instance IDs to `instance-ids.txt`:
+
+```bash
+aws ec2 terminate-instances \
+    --instance-ids $(cat instance-ids.txt | tr '\n' ' ')
+```
 
 #### Upgrading Vault
 

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -66,7 +66,7 @@ Refer to instructions [here](ca/README.md).
 
 By default, the following paths are assumed while building the AMIs:
 
-- Root CA: `ca/
+__TODO__: Fill this up!
 
 ### Preparing Secrets
 
@@ -101,6 +101,9 @@ to specify AWS credentials.
 Refer to each of the directories for instruction.
 
 Take note of the AMI IDs returned from this.
+
+__TODO__: Differentiate between initial "bootstrap" variables in Packer templates and post
+"bootstrap" variables. Also, deal with "common" variable files.
 
 ## Defining Variables
 

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -315,6 +315,8 @@ aws autoscaling update-auto-scaling-group \
     --desired-capacity xxx
 ```
 
+Wait for the new nodes to be ready and first before you continue.
+
 4. Find the Nomad node IDs for each instance. Assuming you have saved the instance IDs to `instance-ids.txt` and that you have kept the default configuration where the node name is the instance ID:
 
 ```bash

--- a/modules/core/ca/README.md
+++ b/modules/core/ca/README.md
@@ -30,7 +30,8 @@ The examples below will make use of the KMS key alias `terraform`.
 
 ## cfssl Configuration
 
-The configuration for `cfssl` is, unfortunately, not present. The best we can do, is to reference
+The documentation for configuration for `cfssl` is, unfortunately, not present.
+The best we can do, is to reference
 the [Go package documentation](https://godoc.org/github.com/cloudflare/cfssl/config). The included
 configuration `config.json` should be sufficient for most purposes.
 

--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -50,8 +50,9 @@ data "template_file" "user_data_nomad_client" {
   template = "${file("${path.module}/user_data/user-data-nomad-client.sh")}"
 
   vars {
-    cluster_tag_key   = "${var.cluster_tag_key}"
+    cluster_tag_key = "${var.cluster_tag_key}"
     cluster_tag_value = "${var.consul_cluster_name}"
+    nomad_vault_integration_consul_prefix = "${var.nomad_vault_integration_consul_prefix}"
   }
 }
 

--- a/modules/core/nomad_servers.tf
+++ b/modules/core/nomad_servers.tf
@@ -54,8 +54,9 @@ data "template_file" "user_data_nomad_server" {
   template = "${file("${path.module}/user_data/user-data-nomad-server.sh")}"
 
   vars {
-    num_servers       = "${var.nomad_servers_num}"
-    cluster_tag_key   = "${var.cluster_tag_key}"
+    num_servers = "${var.nomad_servers_num}"
+    cluster_tag_key  = "${var.cluster_tag_key}"
     cluster_tag_value = "${var.consul_cluster_name}"
+    nomad_vault_integration_consul_prefix = "${var.nomad_vault_integration_consul_prefix}"
   }
 }

--- a/modules/core/packer/common/consul_gossip.json
+++ b/modules/core/packer/common/consul_gossip.json
@@ -1,4 +1,0 @@
-{
-    "consul_gossip": "false",
-    "consul_gossip_key": ""
-}

--- a/modules/core/packer/common/consul_gossip.json
+++ b/modules/core/packer/common/consul_gossip.json
@@ -1,0 +1,4 @@
+{
+    "consul_gossip": "false",
+    "consul_gossip_key": ""
+}

--- a/modules/core/packer/consul/README.md
+++ b/modules/core/packer/consul/README.md
@@ -5,6 +5,19 @@ Consul agent as its DNS server.
 
 This is based on this [example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami).
 
+## Pre-requisite
+
+### Gossip Encryption
+
+As part of the pre-requisite, you should have generated Gossip encryption keys for Consul. Be sure
+to include the common Consul gossip encryption variable file as recommended.
+
+### Certificate Authority
+
+As part of the pre-requisites, you should already have generated certificates for a CA and,
+a certificate for Consul. You should install the certificate for Consul by pointing Packer to the
+path of the Certificate and CA.
+
 ## Configuration Options
 
 See [this page](https://www.packer.io/docs/templates/user-variables.html) for more information.
@@ -17,6 +30,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a VPC is to use the public IP address if available, otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
 - `consul_module_version`: Version of the [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
 - `consul_version`: Version of Consul to install
+- `self_signed_ca`: An array string of paths to CA certificates to install on the AMI.
 
 ## Building Image
 

--- a/modules/core/packer/consul/README.md
+++ b/modules/core/packer/consul/README.md
@@ -7,10 +7,10 @@ This is based on this [example](https://github.com/hashicorp/terraform-aws-nomad
 
 ## Pre-requisite
 
-### Gossip Encryption
+<!-- ### Gossip Encryption
 
 As part of the pre-requisite, you should have generated Gossip encryption keys for Consul. Be sure
-to include the common Consul gossip encryption variable file as recommended.
+to include the common Consul gossip encryption variable file as recommended. -->
 
 ### Certificate Authority
 
@@ -30,7 +30,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a VPC is to use the public IP address if available, otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
 - `consul_module_version`: Version of the [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
 - `consul_version`: Version of Consul to install
-- `self_signed_ca`: An array string of paths to CA certificates to install on the AMI.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image
 

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -8,7 +8,7 @@
         "associate_public_ip_address": "true",
         "ssh_interface": "",
         "consul_module_version": "v0.3.1",
-        "consul_version": "1.0.6",
+        "consul_version": "1.0.7",
         "ca_certificate": ""
     },
     "builders": [

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -8,7 +8,8 @@
         "associate_public_ip_address": "true",
         "ssh_interface": "",
         "consul_module_version": "v0.3.1",
-        "consul_version": "1.0.6"
+        "consul_version": "1.0.6",
+        "ca_certificate": ""
     },
     "builders": [
         {
@@ -64,6 +65,8 @@
             "extra_arguments": [
                 "--extra-vars",
                 "consul_module_version={{user `consul_module_version`}} consul_version={{user `consul_version`}}",
+                "--extra-vars",
+                "ca_certificate={{user `ca_certificate`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -4,6 +4,7 @@
   vars:
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"
+    ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -13,3 +14,11 @@
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"
+  - name: Install CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../roles/ansible-ca-store"
+    vars:
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -5,6 +5,14 @@ Consul agent as its DNS server.
 
 This is based on this [example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami).
 
+## Pre-requisite
+
+### Certificate Authority
+
+As part of the pre-requisites, you should already have generated certificates for a CA and,
+a certificate for Consul. You should install the certificate for Consul by pointing Packer to the
+path of the Certificate and CA.
+
 ## Configuration Options
 
 See [this page](https://www.packer.io/docs/templates/user-variables.html) for more information.
@@ -20,6 +28,9 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `nomad_module_version`: Version of the [Nomad Module](https://github.com/hashicorp/terraform-aws-nomad) to use.
 - `consul_version`: Version of Consul to install
 - `docker_version`: Version of docker to install.
+- `vault_version`: Version of Vault to install
+- `vault_module_version`: Version of the [vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -29,7 +29,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `consul_version`: Version of Consul to install
 - `docker_version`: Version of docker to install.
 - `vault_version`: Version of Vault to install
-- `vault_module_version`: Version of the [vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `vault_module_version`: Version of the [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -11,7 +11,7 @@
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
         "consul_version": "1.0.6",
-        "docker_version": "18.02.0~ce-0~ubuntu"
+        "docker_version": "18.04.0~ce~3-0~ubuntu"
     },
     "builders": [
         {

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -10,7 +10,7 @@
         "nomad_version": "0.8.1",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
-        "consul_version": "1.0.6",
+        "consul_version": "1.0.7",
         "vault_module_version": "v0.5.1",
         "vault_version": "0.10.0",
         "docker_version": "18.04.0~ce~3-0~ubuntu",

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -7,7 +7,7 @@
         "temporary_security_group_source_cidr": "0.0.0.0/0",
         "associate_public_ip_address": "true",
         "ssh_interface": "",
-        "nomad_version": "0.8.0",
+        "nomad_version": "0.8.1",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
         "consul_version": "1.0.6",

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -13,7 +13,8 @@
         "consul_version": "1.0.6",
         "vault_module_version": "v0.5.1",
         "vault_version": "0.10.0",
-        "docker_version": "18.04.0~ce~3-0~ubuntu"
+        "docker_version": "18.04.0~ce~3-0~ubuntu",
+        "ca_certificate": ""
     },
     "builders": [
         {
@@ -71,6 +72,8 @@
                 "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}} docker_version={{user `docker_version`}}",
                 "--extra-vars",
                 "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
+                "--extra-vars",
+                "ca_certificate={{user `ca_certificate`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -11,6 +11,8 @@
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
         "consul_version": "1.0.6",
+        "vault_module_version": "v0.5.1",
+        "vault_version": "0.10.0",
         "docker_version": "18.04.0~ce~3-0~ubuntu"
     },
     "builders": [
@@ -67,6 +69,8 @@
             "extra_arguments": [
                 "--extra-vars",
                 "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}} docker_version={{user `docker_version`}}",
+                "--extra-vars",
+                "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -2,7 +2,7 @@
 - name: Provision AMI
   hosts: all
   vars:
-    nomad_version: "0.7.0"
+    nomad_version: "0.8.0"
     nomad_module_version: "v0.1.1"
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -9,6 +9,7 @@
     docker_version: "17.11.0~ce-0~ubuntu"
     vault_version: "0.10.0"
     vault_module_version: "v0.4.0"
+    ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -31,3 +32,11 @@
   - name: Install Docker and Docker Compose
     include_role:
       name: "{{ playbook_dir }}/../roles/ansible-docker-ubuntu"
+  - name: Install CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../roles/ansible-ca-store"
+    vars:
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -2,7 +2,7 @@
 - name: Provision AMI
   hosts: all
   vars:
-    nomad_version: "0.8.0"
+    nomad_version: "0.8.1"
     nomad_module_version: "v0.1.1"
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -7,6 +7,8 @@
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"
     docker_version: "17.11.0~ce-0~ubuntu"
+    vault_version: "0.10.0"
+    vault_module_version: "v0.4.0"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -20,6 +22,9 @@
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"
+  - name: Install Vault
+    include_role:
+      name: "{{ playbook_dir }}/../roles/install-vault"
   - name: Install Nomad
     include_role:
       name: "{{ playbook_dir }}/../roles/nomad"

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -20,7 +20,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `nomad_module_version`: Version of the [Nomad Module](https://github.com/hashicorp/terraform-aws-nomad) to use.
 - `consul_version`: Version of Consul to install
 - `vault_version`: Version of Vault to install
-- `vault_module_version`: Version of the [vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `vault_module_version`: Version of the [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -19,6 +19,9 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `consul_module_version`: Version of the [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
 - `nomad_module_version`: Version of the [Nomad Module](https://github.com/hashicorp/terraform-aws-nomad) to use.
 - `consul_version`: Version of Consul to install
+- `vault_version`: Version of Vault to install
+- `vault_module_version`: Version of the [vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -10,7 +10,7 @@
         "nomad_version": "0.8.1",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
-        "consul_version": "1.0.6",
+        "consul_version": "1.0.7",
         "vault_module_version": "v0.5.1",
         "vault_version": "0.10.0",
         "ca_certificate": ""

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -12,7 +12,8 @@
         "nomad_module_version": "v0.4.0",
         "consul_version": "1.0.6",
         "vault_module_version": "v0.5.1",
-        "vault_version": "0.10.0"
+        "vault_version": "0.10.0",
+        "ca_certificate": ""
     },
     "builders": [
         {
@@ -70,6 +71,8 @@
                 "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}}",
                 "--extra-vars",
                 "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
+                "--extra-vars",
+                "ca_certificate={{user `ca_certificate`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -7,7 +7,7 @@
         "temporary_security_group_source_cidr": "0.0.0.0/0",
         "associate_public_ip_address": "true",
         "ssh_interface": "",
-        "nomad_version": "0.8.0",
+        "nomad_version": "0.8.1",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
         "consul_version": "1.0.6",

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -10,7 +10,9 @@
         "nomad_version": "0.8.0",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
-        "consul_version": "1.0.6"
+        "consul_version": "1.0.6",
+        "vault_module_version": "v0.5.1",
+        "vault_version": "0.10.0"
     },
     "builders": [
         {
@@ -66,6 +68,8 @@
             "extra_arguments": [
                 "--extra-vars",
                 "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}}",
+                "--extra-vars",
+                "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -10,8 +10,7 @@
         "nomad_version": "0.8.0",
         "consul_module_version": "v0.3.1",
         "nomad_module_version": "v0.4.0",
-        "consul_version": "1.0.6",
-        "docker_version": "18.02.0~ce-0~ubuntu"
+        "consul_version": "1.0.6"
     },
     "builders": [
         {
@@ -66,7 +65,7 @@
             "playbook_file": "{{ template_dir }}/site.yml",
             "extra_arguments": [
                 "--extra-vars",
-                "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}} docker_version={{user `docker_version`}}",
+                "nomad_version={{user `nomad_version`}} consul_module_version={{user `consul_module_version`}} nomad_module_version={{user `nomad_module_version`}} consul_version={{user `consul_version`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -2,7 +2,7 @@
 - name: Provision AMI
   hosts: all
   vars:
-    nomad_version: "0.7.0"
+    nomad_version: "0.8.0"
     nomad_module_version: "v0.1.1"
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -8,6 +8,7 @@
     consul_version: "1.0.1"
     vault_version: "0.10.0"
     vault_module_version: "v0.4.0"
+    ca_certificate: ""
   pre_tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -23,3 +24,11 @@
   - name: Install Nomad
     include_role:
       name: "{{ playbook_dir }}/../roles/nomad"
+  - name: Install CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../roles/ansible-ca-store"
+    vars:
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -6,6 +6,8 @@
     nomad_module_version: "v0.1.1"
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"
+    vault_version: "0.10.0"
+    vault_module_version: "v0.4.0"
   pre_tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -15,6 +17,9 @@
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"
+  - name: Install Vault
+    include_role:
+      name: "{{ playbook_dir }}/../roles/install-vault"
   - name: Install Nomad
     include_role:
       name: "{{ playbook_dir }}/../roles/nomad"

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -2,7 +2,7 @@
 - name: Provision AMI
   hosts: all
   vars:
-    nomad_version: "0.8.0"
+    nomad_version: "0.8.1"
     nomad_module_version: "v0.1.1"
     consul_module_version: "v0.1.0"
     consul_version: "1.0.1"

--- a/modules/core/packer/roles/ansible/defaults/main.yml
+++ b/modules/core/packer/roles/ansible/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ansible_install_version: "2.5.0"
+ansible_install_version: "2.5.1"

--- a/modules/core/packer/roles/ansible/meta/main.yml
+++ b/modules/core/packer/roles/ansible/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - { role: "pip3" }

--- a/modules/core/packer/roles/ansible/tasks/main.yml
+++ b/modules/core/packer/roles/ansible/tasks/main.yml
@@ -1,12 +1,23 @@
 ---
-- name: Install OpenSSL headers
+- name: Get Ubuntu release name
+  shell: lsb_release -cs
+  register: release_name
+- name: Install dependencies
   apt:
-    name: libssl-dev
+    name: "{{ item }}"
     state: latest
+  with_items:
+    - "libssl-dev"
+    - "software-properties-common"
   become: yes
-- name: Install with Pip
-  pip:
-    name: "ansible"
-    version: "{{ ansible_install_version }}"
+- name: Add Ansible PPA
+  apt_repository:
+    repo: "ppa:ansible/ansible"
+    state: present
+    update_cache: yes
+  become: yes
+- name: Install Ansible
+  apt:
+    name: "ansible={{ ansible_install_version }}-1ppa~{{ release_name.stdout }}"
     state: present
   become: yes

--- a/modules/core/packer/roles/install-kms-aes/defaults/main.yml
+++ b/modules/core/packer/roles/install-kms-aes/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 kms_aes_module_url: "https://github.com/GovTechSG/kms-aes.git"
-kms_aes_module_version: "v0.0.2"
+kms_aes_module_version: "v0.0.3"
 kms_aes_module_dest: "/opt/aes-kms"

--- a/modules/core/packer/roles/install-vault/README.md
+++ b/modules/core/packer/roles/install-vault/README.md
@@ -1,0 +1,3 @@
+# install-vault
+
+This role only installs Vault CLI to be available in PATH.

--- a/modules/core/packer/roles/install-vault/defaults/main.yml
+++ b/modules/core/packer/roles/install-vault/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+vault_version: "0.10.0"
+vault_module_version: "v0.4.0"
+vault_module_url: "https://github.com/hashicorp/terraform-aws-vault.git"

--- a/modules/core/packer/roles/install-vault/tasks/main.yml
+++ b/modules/core/packer/roles/install-vault/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Install git
+  apt:
+    name: git
+    state: latest
+  become: yes
+- name: Checkout Vault module
+  git:
+    repo: "{{ vault_module_url }}"
+    dest: "/tmp/terraform-aws-vault"
+    version: "{{ vault_module_version }}"
+- name: Install Vault
+  shell: "/tmp/terraform-aws-vault/modules/install-vault/install-vault --version {{ vault_version }}"

--- a/modules/core/packer/roles/nomad/defaults/main.yml
+++ b/modules/core/packer/roles/nomad/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-  nomad_version: "0.8.0"
+  nomad_version: "0.8.1"
   nomad_module_url: "https://github.com/hashicorp/terraform-aws-nomad.git"
   nomad_module_version: "v0.1.1"
   docker_version: "18.04.0~ce~3-0~ubuntu"

--- a/modules/core/packer/roles/nomad/defaults/main.yml
+++ b/modules/core/packer/roles/nomad/defaults/main.yml
@@ -2,4 +2,4 @@
   nomad_version: "0.8.0"
   nomad_module_url: "https://github.com/hashicorp/terraform-aws-nomad.git"
   nomad_module_version: "v0.1.1"
-  docker_version: "18.02.0~ce-0~ubuntu"
+  docker_version: "18.04.0~ce~3-0~ubuntu"

--- a/modules/core/packer/roles/nomad/files/configure-vault.sh
+++ b/modules/core/packer/roles/nomad/files/configure-vault.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Note: This script works assumes that there is a Consul agent running on localhost and that
-# DNSMasq has been setup to query the Consul agent.
+# Note: This script works assumes that the non-configurable  defaults setup by the Ansible roles
+# and the `core` and `nomad-vault-integration` modules are not changed. Otherwise, it will fail to
+# find the right values and will not work.
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"

--- a/modules/core/packer/roles/nomad/files/configure-vault.sh
+++ b/modules/core/packer/roles/nomad/files/configure-vault.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Note: This script works assumes that the non-configurable  defaults setup by the Ansible roles
+# Note: This script works assumes that the non-configurable defaults setup by the Ansible roles
 # and the `core` and `nomad-vault-integration` modules are not changed. Otherwise, it will fail to
 # find the right values and will not work.
 

--- a/modules/core/packer/roles/nomad/files/configure-vault.sh
+++ b/modules/core/packer/roles/nomad/files/configure-vault.sh
@@ -242,7 +242,6 @@ function main {
 
   local integration_enabled
   integration_enabled=$(consul_kv "${consul_prefix}enabled")
-  echo "${integration_enabled}"
   if [[ "${integration_enabled}" != "yes" ]]; then
     log_info "Nomad Vault integration is not enabled"
     exit 0

--- a/modules/core/packer/roles/nomad/files/configure-vault.sh
+++ b/modules/core/packer/roles/nomad/files/configure-vault.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Note: This script works assumes that there is a Consul agent running on localhost and that
+# DNSMasq has been setup to query the Consul agent.
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+function print_usage {
+  echo
+  echo "Usage: configure-vault [OPTIONS]"
+  echo
+  echo "This script is used to configure Nomad for Vault integration on an AWS server."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --server\t\tIf set, configure in server mode. Optional. Exactly one of --server or --client must be set."
+  echo -e "  --client\t\tIf set, configure in client mode. Optional. Exactly one of --server or --client must be set."
+  echo -e "  --config-dir\t\tThe path to write the config file to. Optional. Default is the absolute path of '../config/vault.hcl', relative to this script."
+  echo -e "  --vault-service\t\tName of Vault service to query in Consul. Optional. Defaults to 'vault'."
+  echo -e "  --vault-port\t\Port of Vault service. Optional. Defaults to '8200'."
+  echo
+  echo "Example:"
+  echo
+  echo "  configure-vault --server"
+}
+
+function assert_not_empty {
+  local readonly arg_name="$1"
+  local readonly arg_value="$2"
+
+  if [[ -z "$arg_value" ]]; then
+    log_error "The value for '$arg_name' cannot be empty"
+    print_usage
+    exit 1
+  fi
+}
+
+function assert_is_installed {
+  local readonly name="$1"
+
+  if [[ ! $(command -v ${name}) ]]; then
+    log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
+    exit 1
+  fi
+}
+
+function generate_config {
+  local readonly server="${1}"
+  local readonly config_path="${2}"
+  local readonly vault_address="${3}"
+
+}
+
+function main {
+  local server="false"
+  local client="false"
+  local config_path=""
+  local vault_service="vault"
+  local vault_port="8200"
+  local all_args=()
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --server)
+        server="true"
+        ;;
+      --client)
+        client="true"
+        ;;
+      --config-path)
+        assert_not_empty "$key" "$2"
+        config_path="$2"
+        shift
+      ;;
+      --vault-service)
+        assert_not_empty "$key" "$2"
+        vault_service="$2"
+        shift
+        ;;
+      --vault-port)
+        assert_not_empty "$key" "$2"
+        vault_port="$2"
+        shift
+        ;;
+      --help)
+        print_usage
+        exit
+        ;;
+      *)
+        log_error "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  if [[ ("$server" == "true" && "$client" == "true") || ("$server" == "false" && "$client" == "false") ]]; then
+    log_error "Exactly one of --server or --client must be set."
+    exit 1
+  fi
+
+  assert_is_installed "curl"
+  assert_is_installed "jq"
+  assert_is_installed "consul"
+  assert_is_installed "vault"
+
+  if [[ -z "$config_path" ]]; then
+    config_path=$(cd "$SCRIPT_DIR/../config/vault.hcl" && pwd)
+  fi
+
+  local readonly vault_address="https://${vault_service}.service.consul:${vault_port}"
+
+  generate_config "${server}" "${config_path}" "${vault_address}"
+}
+
+main "$@"

--- a/modules/core/packer/roles/nomad/tasks/main.yml
+++ b/modules/core/packer/roles/nomad/tasks/main.yml
@@ -16,3 +16,9 @@
     src: "{{ role_path }}/files/config/"
     dest: "/opt/nomad/config"
   become: yes
+- name: Install Vault Configuration script
+  copy:
+    src: "{{ role_path }}/files/configure-vault.sh"
+    dest: "/opt/nomad/bin/configure-vault"
+    mode: 0755
+  become: yes

--- a/modules/core/packer/roles/vault/defaults/main.yml
+++ b/modules/core/packer/roles/vault/defaults/main.yml
@@ -1,8 +1,5 @@
 ---
-vault_version: "0.10.0"
 vault_ui_enable: "true"
-vault_module_version: "v0.4.0"
-vault_module_url: "https://github.com/hashicorp/terraform-aws-vault.git"
 consul_key: "vault/"
 
 tls_cert_file_src: "{{ playbook_dir }}/cert/cert.pem"

--- a/modules/core/packer/roles/vault/meta/main.yml
+++ b/modules/core/packer/roles/vault/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
   - { role: "aws-cli" }
   - { role: "ansible" }
   - { role: "install-kms-aes" }
+  - { role: "install-vault" }

--- a/modules/core/packer/roles/vault/tasks/main.yml
+++ b/modules/core/packer/roles/vault/tasks/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: Install git
-  apt:
-    name: git
-    state: latest
-  become: yes
-- name: Checkout Vault module
-  git:
-    repo: "{{ vault_module_url }}"
-    dest: "/tmp/terraform-aws-vault"
-    version: "{{ vault_module_version }}"
-- name: Install Vault
-  shell: "/tmp/terraform-aws-vault/modules/install-vault/install-vault --version {{ vault_version }}"
 - name: "Template Vault Configuration"
   template:
     src: "{{ role_path }}/files/config/override.hcl"

--- a/modules/core/packer/vault/README.md
+++ b/modules/core/packer/vault/README.md
@@ -71,7 +71,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a VPC is to use the public IP address if available, otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
 - `vault_version`: Version of Vault to install
 - `consul_module_version`: Version of the [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
-- `vault_module_version`: Version of the [vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `vault_module_version`: Version of the [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `vault_ui_enable`: Enable UI for Vault or not. Defaults to `true`.
 - `consul_version`: Version of Consul to install
 - `consul_key`: Key in Consul to store Vault HA information in

--- a/modules/core/packer/vault/README.md
+++ b/modules/core/packer/vault/README.md
@@ -79,6 +79,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `encrypted_tls_key_file_src`: Encrypted private key for the certificate. This defaults to `cert/cert.key` if you used the instructions above.
 - `encrypted_aes_key_src`: AES data key used to encrypt the private key, which is in turned encrypted by AWS KMS. Defaults to `cert/aes.key` if you used the instructions above.
 - `cli_json_src`: The AWS CLI JSON file used to encrypt the AES key. This defaults to `cert/cli.json` if you used the instructions above.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
 
 ## Building Image
 

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -16,7 +16,8 @@
         "tls_cert_file_src": "{{ template_dir }}/cert/cert.pem",
         "encrypted_tls_key_file_src": "{{ template_dir }}/cert/cert.key",
         "encrypted_aes_key_src": "{{ template_dir }}/cert/aes.key",
-        "cli_json_src": "{{ template_dir }}/cert/cli.json"
+        "cli_json_src": "{{ template_dir }}/cert/cli.json",
+        "ca_certificate": ""
     },
     "builders": [
         {
@@ -76,6 +77,8 @@
                 "vault_module_version={{user `vault_module_version`}} consul_version={{user `consul_version`}} consul_key={{user `consul_key`}}",
                 "-e",
                 "tls_cert_file_src={{user `tls_cert_file_src`}} encrypted_tls_key_file_src={{user `encrypted_tls_key_file_src`}} encrypted_aes_key_src={{user `encrypted_aes_key_src`}} cli_json_src={{user `cli_json_src`}}",
+                "--extra-vars",
+                "ca_certificate={{user `ca_certificate`}}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -11,7 +11,7 @@
         "vault_module_version": "v0.5.1",
         "vault_version": "0.10.0",
         "vault_ui_enable": "true",
-        "consul_version": "1.0.6",
+        "consul_version": "1.0.7",
         "consul_key": "vault",
         "tls_cert_file_src": "{{ template_dir }}/cert/cert.pem",
         "encrypted_tls_key_file_src": "{{ template_dir }}/cert/cert.key",

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -12,6 +12,7 @@
     encrypted_tls_key_file_src: "{{ playbook_dir }}/cert/encrypted_vault.key"
     encrypted_aes_key_src: "{{ playbook_dir }}/cert/aes.key"
     cli_json_src: "{{ playbook_dir }}/cert/cli.json"
+    ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -24,3 +25,11 @@
   - name: Install Vault
     include_role:
       name: "{{ playbook_dir }}/../roles/vault"
+  - name: Install CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../roles/ansible-ca-store"
+    vars:
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -6,7 +6,7 @@
     vault_ui_enable: "true"
     vault_module_version: "v0.4.0"
     consul_module_version: "v0.1.2"
-    consul_version: "1.0.6"
+    consul_version: "1.0.7"
     consul_key: "vault/"
     tls_cert_file_src: "{{ playbook_dir }}/cert/cert.pem"
     encrypted_tls_key_file_src: "{{ playbook_dir }}/cert/encrypted_vault.key"

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in server mode. Note that this script assumes it's running in an AMI
 # built from the Packer template in examples/consul-ami/consul.json in the Consul AWS Module.

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in client mode and the run-nomad script to configure and start Nomad
 # in client mode. Note that this script assumes it's running in an AMI built from the Packer template in

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -18,6 +18,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # Configure Vault Integration
 /opt/nomad/bin/configure-vault \
-    --client
+    --client \
+    --consul-prefix "${nomad_vault_integration_consul_prefix}"
 
 /opt/nomad/bin/run-nomad --client

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -15,4 +15,9 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --client \
     --cluster-tag-key "${cluster_tag_key}" \
     --cluster-tag-value "${cluster_tag_value}"
+
+# Configure Vault Integration
+/opt/nomad/bin/configure-vault \
+    --client
+
 /opt/nomad/bin/run-nomad --client

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -18,6 +18,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # Configure Vault Integration
 /opt/nomad/bin/configure-vault \
-    --server
+    --server \
+    --consul-prefix "${nomad_vault_integration_consul_prefix}"
 
 /opt/nomad/bin/run-nomad --server --num-servers "${num_servers}"

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in client mode and then the run-nomad script to configure and start
 # Nomad in server mode. Note that this script assumes it's running in an AMI built from the Packer template in

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -10,8 +10,14 @@ set -e
 # From: https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
+# Configure and run Consul
 /opt/consul/bin/run-consul \
     --client \
     --cluster-tag-key "${cluster_tag_key}" \
     --cluster-tag-value "${cluster_tag_value}"
+
+# Configure Vault Integration
+/opt/nomad/bin/configure-vault \
+    --server
+
 /opt/nomad/bin/run-nomad --server --num-servers "${num_servers}"

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script is meant to be run in the User Data of each EC2 Instance while it's booting. The script uses the
 # run-consul script to configure and start Consul in client mode and then the run-vault script to configure and start
 # Vault in server mode. Note that this script assumes it's running in an AMI built from the Packer template in

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -316,3 +316,15 @@ variable "elb_ssl_policy" {
   description = "ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html"
   default = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
+
+# --------------------------------------------------------------------------------------------------
+# Post Bootstrap Integration Parameters
+# These parameters are used in conjunction with the other modules in this repository.
+# If you change the values in the other modules, you have to update them too.
+# --------------------------------------------------------------------------------------------------
+variable "nomad_vault_integration_consul_prefix" {
+  description = <<EOF
+  The Consul prefix used by the Nomad Vault integration script during initial instance boot.
+EOF
+  default = "terraform/nomad-vault-integration/"
+}

--- a/modules/nomad-vault-integration/README.md
+++ b/modules/nomad-vault-integration/README.md
@@ -17,3 +17,10 @@ Instead of generating a Vault Token by hand while configuring Nomad, we instead 
 Vault to enable the [AWS authentication method](https://www.vaultproject.io/docs/auth/aws.html) so
 that Nomad servers instance will be able to retrieve a token on first boot purely by authenticating
 with Vault via their Instance Profile.
+
+## Integration with `Core` module
+
+After you have applied this module, a key will be set in Consul's KV store. The default
+`user_data` scripts of the Core's Nomad servers and clients will check for the presence of this
+key in Consul to configure themselves accordingly. Refer to the Core module's documentation on how
+to update your Nomad cluster.

--- a/modules/nomad-vault-integration/README.md
+++ b/modules/nomad-vault-integration/README.md
@@ -14,6 +14,10 @@ Your Vault instances must also have the appropriate
 [IAM policy](https://www.vaultproject.io/docs/auth/aws.html#recommended-vault-iam-policy) applied
 to them. Otherwise, the instances cannot perform verification with the AWS API.
 
+This module includes Terraforming the IAM policy, if you choose to enable it via the
+`create_iam_policy` variable. The policy created by this module does not include the
+`sts:AssumeRole` action, which is only needed if you want to use cross account access.
+
 ## Vault Provider
 
 Refer to the [documentation](https://www.terraform.io/docs/providers/vault/index.html) on the

--- a/modules/nomad-vault-integration/README.md
+++ b/modules/nomad-vault-integration/README.md
@@ -5,6 +5,15 @@ This module is an example on how you can setup integration between Vault and Nom
 
 This is intended to be used alongside the [core](../core) module.
 
+## Pre-requisites
+
+You must have Terraformed the [core](../core) module first. In addition, you must have at least
+initialised and unsealed the Vault servers.
+
+Your Vault instances must also have the appropriate
+[IAM policy](https://www.vaultproject.io/docs/auth/aws.html#recommended-vault-iam-policy) applied
+to them. Otherwise, the instances cannot perform verification with the AWS API.
+
 ## Vault Provider
 
 Refer to the [documentation](https://www.terraform.io/docs/providers/vault/index.html) on the

--- a/modules/nomad-vault-integration/iam.tf
+++ b/modules/nomad-vault-integration/iam.tf
@@ -32,7 +32,7 @@ resource "aws_iam_policy" "vault_aws_auth" {
 }
 
 resource "aws_iam_role_policy_attachment" "vault_aws_auth" {
-     count = "${var.create_iam_policy ? 1 : 0}"
+    count = "${var.create_iam_policy ? 1 : 0}"
 
     role = "${var.vault_iam_role_id}"
     policy_arn = "${aws_iam_policy.vault_aws_auth.arn}"

--- a/modules/nomad-vault-integration/iam.tf
+++ b/modules/nomad-vault-integration/iam.tf
@@ -1,0 +1,39 @@
+#################################################
+# IAM Policy to allow Vault servers to perform IAM authentication
+# See https://www.vaultproject.io/docs/auth/aws.html
+#################################################
+# From https://www.vaultproject.io/docs/auth/aws.html#recommended-vault-iam-policy
+data "aws_iam_policy_document" "vault_aws_auth" {
+    count = "${var.create_iam_policy ? 1 : 0}"
+
+    policy_id = "${var.iam_role_name}"
+
+    statement {
+        effect = "Allow"
+        actions = [
+            "ec2:DescribeInstances",
+            "iam:GetInstanceProfile",
+            "iam:GetUser",
+            "iam:GetRole"
+        ]
+
+        resources = [
+            "*"
+        ]
+    }
+}
+
+resource "aws_iam_policy" "vault_aws_auth" {
+    count = "${var.create_iam_policy ? 1 : 0}"
+
+    name = "${var.iam_role_name}"
+    description = "Policy to allow Vault instances to authenticate entities with AWS IAM. See https://www.vaultproject.io/docs/auth/aws.html"
+    policy = "${data.aws_iam_policy_document.vault_aws_auth.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "vault_aws_auth" {
+     count = "${var.create_iam_policy ? 1 : 0}"
+
+    role = "${var.vault_iam_role_id}"
+    policy_arn = "${aws_iam_policy.vault_aws_auth.arn}"
+}

--- a/modules/nomad-vault-integration/main.tf
+++ b/modules/nomad-vault-integration/main.tf
@@ -75,6 +75,7 @@ resource "consul_key_prefix" "core_integration" {
         "allow_unauthenticated" = "${var.allow_unauthenticated}"
         "create_from_role" = "${var.nomad_token_role}"
         "nomad_server_role" = "${var.nomad_aws_token_role}"
+        "auth_path" = "${var.aws_auth_path}"
         "README" = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/nomad-vault-integration"
     }
 }

--- a/modules/nomad-vault-integration/main.tf
+++ b/modules/nomad-vault-integration/main.tf
@@ -32,7 +32,6 @@ data "template_file" "nomad_aws_token_role" {
 
     vars {
         nomad_server_policy = "${var.nomad_server_policy}"
-        nomad_token_role = "${var.nomad_token_role}"
         nomad_server_iam_role_arn = "${var.nomad_server_iam_role_arn}"
     }
 }

--- a/modules/nomad-vault-integration/main.tf
+++ b/modules/nomad-vault-integration/main.tf
@@ -53,6 +53,7 @@ data "template_file" "nomad_server_token_role" {
     vars {
         nomad_server_policy = "${var.nomad_server_policy}"
         nomad_token_role = "${var.nomad_token_role}"
+        path_suffix = "${var.nomad_token_suffix}"
     }
 }
 

--- a/modules/nomad-vault-integration/main.tf
+++ b/modules/nomad-vault-integration/main.tf
@@ -67,6 +67,13 @@ resource "vault_generic_secret" "nomad_server_token_role" {
 # Mark in Consul for the `core` module scripts to configure themselves
 ################################################
 resource "consul_key_prefix" "core_integration" {
+    depends_on = [
+        "vault_auth_backend.aws",
+        "vault_policy.nomad_server_policy",
+        "vault_generic_secret.nomad_aws_token_role",
+        "vault_generic_secret.nomad_server_token_role"
+    ]
+
     count = "${var.core_integration ? 1 : 0}"
     path_prefix = "${var.consul_key_prefix}"
 

--- a/modules/nomad-vault-integration/templates/vault_token_role.json
+++ b/modules/nomad-vault-integration/templates/vault_token_role.json
@@ -4,7 +4,7 @@
     "explicit_max_ttl": 0,
     "name": "${nomad_token_role}",
     "orphan": true,
-    "path_suffix": "",
+    "path_suffix": "${path_suffix}",
     "period": 259200,
     "renewable": true
 }

--- a/modules/nomad-vault-integration/variables.tf
+++ b/modules/nomad-vault-integration/variables.tf
@@ -30,6 +30,21 @@ variable "nomad_token_role" {
     default = "nomad-cluster"
 }
 
+variable "create_iam_policy" {
+    description = "Enable this module to create the appropriate IAM policy for your Vault instances"
+    default = false
+}
+
+variable "iam_role_name" {
+    description = "If `create_iam_policy` is enabled, this will be the name of the policy created"
+    default = "VaultAwsAuth"
+}
+
+variable "vault_iam_role_id" {
+    description = "If `create_iam_policy` is enabled, this will be the Vault IAM role ID to apply the policy to"
+    default = ""
+}
+
 # --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------

--- a/modules/nomad-vault-integration/variables.tf
+++ b/modules/nomad-vault-integration/variables.tf
@@ -30,6 +30,11 @@ variable "nomad_token_role" {
     default = "nomad-cluster"
 }
 
+variable "nomad_token_suffix" {
+    description = "Suffix to create tokens with. See https://www.vaultproject.io/api/auth/token/index.html#path_suffix for more information"
+    default = "nomad-cluster"
+}
+
 variable "create_iam_policy" {
     description = "Enable this module to create the appropriate IAM policy for your Vault instances"
     default = false

--- a/modules/nomad-vault-integration/variables.tf
+++ b/modules/nomad-vault-integration/variables.tf
@@ -29,3 +29,21 @@ variable "nomad_token_role" {
     description = "Name for the Token role that is used by the Nomad server to create tokens"
     default = "nomad-cluster"
 }
+
+# --------------------------------------------------------------------------------------------------
+# CORE INTEGRATION SETTINGS
+# --------------------------------------------------------------------------------------------------
+variable "core_integration" {
+    description = "Enable integration with the `core` module by setting some values in Consul so that the user_data scripts in core know that this module has been applied"
+    default = true
+}
+
+variable "consul_key_prefix" {
+    description = "Path prefix to the key in Consul to set for the `core` module to know that this module has been applied."
+    default = "terraform/nomad-vault-integration/"
+}
+
+variable "allow_unauthenticated" {
+    description = "Specifies if users submitting jobs to the Nomad server should be required to provide their own Vault token, proving they have access to the policies listed in the job. This option should be disabled in an untrusted environment."
+    default = "false"
+}

--- a/modules/nomad-vault-integration/variables.tf
+++ b/modules/nomad-vault-integration/variables.tf
@@ -54,16 +54,27 @@ variable "vault_iam_role_id" {
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------
 variable "core_integration" {
-    description = "Enable integration with the `core` module by setting some values in Consul so that the user_data scripts in core know that this module has been applied"
+    description = <<EOF
+        Enable integration with the `core` module by setting some values in Consul so
+        that the user_data scripts in core know that this module has been applied
+EOF
     default = true
 }
 
 variable "consul_key_prefix" {
-    description = "Path prefix to the key in Consul to set for the `core` module to know that this module has been applied."
+    description = <<EOF
+        Path prefix to the key in Consul to set for the `core` module to know that this module has
+        been applied. If you change this, you have to update the
+        `nomad_vault_integration_consul_prefix` variable in the core module as well.
+EOF
     default = "terraform/nomad-vault-integration/"
 }
 
 variable "allow_unauthenticated" {
-    description = "Specifies if users submitting jobs to the Nomad server should be required to provide their own Vault token, proving they have access to the policies listed in the job. This option should be disabled in an untrusted environment."
+    description = <<EOF
+        Specifies if users submitting jobs to the Nomad server should be required to provide
+        their own Vault token, proving they have access to the policies listed in the job.
+        This option should be disabled in an untrusted environment.
+EOF
     default = "false"
 }


### PR DESCRIPTION
- The design of this system is done with "immutable infrastructure" in mind. That is once instances are initially bootstrapped and configured, new changes and integrations should be done by terminating old instances and spinning up new instances with the new configuration.
- The `core` module is for initial bootstrap and ongoing configuration for this new (and future) integration. This is especially so for integration with Vault because Vault requires manual operation for initialisation and unsealing (at least for the OSS versions).
- The `user_data` scripts of the instances will check using the Consul KV stores on whether other integrations are terraformed and enabled. If they are, the scripts will then perform the necessary configuration for integration.
- The new `nomad-vault-integration` is one such new module that will write values to the Consul KV store when it is done.
- We prevent circular dependencies between the `core` module and other modules. 