### PR TITLE
Vault packer README cleanup

### DIFF
--- a/modules/core/ca/.gitignore
+++ b/modules/core/ca/.gitignore
@@ -1,1 +1,2 @@
 *-key.pem
+*.csr

--- a/modules/core/ca/README.md
+++ b/modules/core/ca/README.md
@@ -7,39 +7,56 @@ certificates for Nomad and other services.
 1. [Create a new master key in AWS KMS](https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html)
 1. Generate a key for the CA and create a cerficiate for the CA.
 1. Encrypt the key with KMS.
-1. (Optional) set up [Grants](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html) for the KMS CMK.
+1. (Optional) set up [Grants](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+   for the KMS CMK.
 1. Store the encrpyted key.
 1. Renew CA with the same key.
 
-The guide will make use of [`cfssl`](https://github.com/cloudflare/cfssl). You can run this in a
-Docker container to simplify operations.
+The guide will make use of [`cfssl`](https://github.com/cloudflare/cfssl). All commands to run are
+assumed to be done in this `ca/` directory.
+
+If you are running on a recent `Ubuntu` machine, you can install `golang-cfssl` from `apt`
+repository:
+
+```bash
+apt install golang-cfssl
+```
+
+Alternatively you can run this in an interactive `bash` shell in Docker container to simplify
+operations:
 
 ```bash
 docker run \
     --rm \
     -it \
-    --entrypoint "" \
+    --entrypoint bash \
     -v `pwd`:/data \
+    -u `id -u`:`id -g` \
+    --name user \
     --workdir /data \
-    --userns host \
-    cfssl/cfssl:1.3.2 \
-    bash
+    cfssl/cfssl:1.3.2
 ```
 
-The examples below will make use of the KMS key alias `terraform`.
+Ignore the `I have no name!` user name display in the interactive shell.
+
+Make sure that all commands (including the above ones) are run in `ca/`. The commands below will be
+be compatible with either of the above methods used.
+
+Also note that below will make use of the KMS key alias `terraform`.
 
 ## cfssl Configuration
 
 The documentation for configuration for `cfssl` is, unfortunately, not present.
-The best we can do, is to reference
-the [Go package documentation](https://godoc.org/github.com/cloudflare/cfssl/config). The included
+
+The best we can do, is to reference the
+[Go package documentation](https://godoc.org/github.com/cloudflare/cfssl/config). The included
 configuration `config.json` should be sufficient for most purposes.
 
 ## CSR Configuration
 
 The documentation for this is sparse. The reference for the
 [Go package](https://godoc.org/github.com/cloudflare/cfssl/csr) and this
-[page](https://github.com/cloudflare/cfssl/wiki/Creating-a-new-CSR) is all we have at this moment.
+[page](https://github.com/cloudflare/cfssl/wiki/Creating-a-new-CSR) are all we have at this moment.
 
 ## Generate a key for the root CA and create a certificate for the root CA
 
@@ -52,9 +69,8 @@ For example
 cfssl gencert -config config.json -profile ca -initca root/csr.json | cfssljson -bare root/ca
 ```
 
-*DO NOT CHECK IN `ca-key.pem` unencrypted!* The CSR does not need to be checked in.
-
-You might need to `chown` the files so that you can read it.
+*DO NOT CHECK IN `ca-key.pem` unencrypted!* The CSR does not need to be checked in. The `.gitignore`
+set-up should prevent this file from being accidentally checked in.
 
 ## Encrypt the CA private key with AWS KMS
 
@@ -63,18 +79,18 @@ You should decide on an Encryption context so that you can use
 to the CA Private key. You _must_ remember the context you have set or you will not be able to
 decrypt the key in the future.
 
-An example context is in `cli.json`.
+An example context is in [`root/cli.json`](root/cli.json).
 
 The following example will encrypt the key and store it in binary.
 
 ```bash
 aws kms encrypt \
     --key-id "alias/terraform" \
-    --plaintext fileb://ca-key.pem \
+    --plaintext fileb://root/ca-key.pem \
     --output text --query CiphertextBlob \
-    --cli-input-json file://cli.json \
+    --cli-input-json file://root/cli.json \
 | base64 --decode \
-> ca.key
+> root/ca.key
 ```
 
 Verify that the encrypted file can be decrypted successfully and equally to the original key file
@@ -82,23 +98,25 @@ Verify that the encrypted file can be decrypted successfully and equally to the 
 
 ```bash
 aws kms decrypt \
-    --ciphertext-blob fileb://ca.key \
+    --ciphertext-blob fileb://root/ca.key \
     --output text \
     --query Plaintext \
-    --cli-input-json file://cli.json \
+    --cli-input-json file://root/cli.json \
 | base64 --decode \
-| diff ca-key.pem - > /dev/null \
+| diff root/ca-key.pem - > /dev/null \
 || echo "The keys are different!"
 ```
 
-You can now safely delete `ca-key.pem`.
+If the message `The keys are different!` does not appear, this means that the set-up is working.
+
+You can now safely delete `root/ca-key.pem`.
 
 ### Viewing the Certificate
 
 You can use the command below to view details of the certificate.
 
 ```bash
-openssl x509 -in ca.pem -text -noout
+openssl x509 -in root/ca.pem -text -noout
 ```
 
 ## Store the encrypted key
@@ -113,20 +131,26 @@ You can store the encrypted key in the repository. The files stored are:
 
 ```bash
 aws kms decrypt \
-    --ciphertext-blob fileb://ca.key \
+    --ciphertext-blob fileb://root/ca.key \
     --output text \
     --query Plaintext \
-    --cli-input-json file://cli.json \
+    --cli-input-json file://root/cli.json \
 | base64 --decode \
-> ca-key.pem
- ```
+> root/ca-key.pem
+```
 
-Don't forget to delete the decrypted key!
+Don't forget to delete the decrypted key! Simply run:
+
+```bash
+rm root/ca-key.pem
+```
+
+to do so.
 
 ## Renew CA with the same key
 
 ```bash
-cfssl gencert -renewca -ca ca.pem -ca-key ca-key.pem
+cfssl gencert -renewca -ca root/ca.pem -ca-key root/ca-key.pem
 ```
 
 ## Issue an intermediate CA
@@ -143,12 +167,23 @@ We will look at the provided example `vault`.
 ```bash
 # Generate a new key pair and CSR
 cfssl genkey -config config.json -profile ca -initca vault/csr.json | cfssljson -bare vault/ca
+
 # Generate a certificate and sign it with the root CA key
 cfssl sign -ca root/ca.pem -ca-key root/ca-key.pem -config config.json -profile ca vault/ca.csr \
     | cfssljson -bare vault/ca
 ```
 
-Don't forget to encrypt the new key.
+You can encrypt the new key with the following command:
+
+```bash
+aws kms encrypt \
+    --key-id "alias/terraform" \
+    --plaintext fileb://vault/ca-key.pem \
+    --output text --query CiphertextBlob \
+    --cli-input-json file://vault/cli.json \
+| base64 --decode \
+> vault/ca.key
+```
 
 ## Issue a new certificate
 
@@ -162,13 +197,24 @@ For example, if we want to generate a new certificate to serve Vault's API:
 ```bash
 # Generate a new key pair and CSR
 cfssl genkey -config config.json -profile peer vault-cert/csr.json | cfssljson -bare vault-cert/cert
+
 # Generate a certificate and sign it with the root CA key
 cfssl sign -ca root/ca.pem -ca-key root/ca-key.pem -config config.json -profile peer \
     vault-cert/cert.csr \
     | cfssljson -bare vault/cert
 ```
 
-Don't forget to encrypt the new key.
+You can encrypt the new key with the following command:
+
+```bash
+aws kms encrypt \
+    --key-id "alias/terraform" \
+    --plaintext fileb://vault-cert/cert-key.pem \
+    --output text --query CiphertextBlob \
+    --cli-input-json file://vault-cert/cli.json \
+| base64 --decode \
+> vault-cert/cert.key
+```
 
 ## Resources
 

--- a/modules/core/ca/README.md
+++ b/modules/core/ca/README.md
@@ -22,8 +22,8 @@ repository:
 apt install golang-cfssl
 ```
 
-Alternatively you can run this in an interactive `bash` shell in Docker container to simplify
-operations:
+Alternatively you can run this in an interactive `bash` shell in Docker container to any commands
+that require the `cfssl` command:
 
 ```bash
 docker run \
@@ -37,12 +37,12 @@ docker run \
     cfssl/cfssl:1.3.2
 ```
 
-Ignore the `I have no name!` user name display in the interactive shell.
+Ignore the `I have no name!` user name display in the interactive shell. This is only for `cfssl`
+command, and other commands such as `aws` and `openssl` should be run on the native set-up, so make
+sure that these other commands exist.
 
-Make sure that all commands (including the above ones) are run in `ca/`. The commands below will be
-be compatible with either of the above methods used.
-
-Also note that below will make use of the KMS key alias `terraform`.
+All commands (including the above ones) are to be run in `ca/`. Also note that all commands below
+will make use of the KMS key alias `terraform`.
 
 ## cfssl Configuration
 

--- a/modules/core/ca/README.md
+++ b/modules/core/ca/README.md
@@ -93,6 +93,8 @@ aws kms encrypt \
 > root/ca.key
 ```
 
+## Decrypt the encrypted CA private key with AWS KMS for verification
+
 Verify that the encrypted file can be decrypted successfully and equally to the original key file
 (be sure not to print the key):
 

--- a/modules/core/packer/vault/README.md
+++ b/modules/core/packer/vault/README.md
@@ -1,29 +1,55 @@
 # Consul and Vault AMI
 
-AMI with Vault and Consul binaries installed. DNSmasq is also configured to use the local
-Consul agent as its DNS server.
+AMI with Vault and Consul binaries installed. DNSmasq is also configured to use the local Consul
+agent as its DNS server.
 
-This is based on this [example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami).
+This is based on this
+[example](https://github.com/hashicorp/terraform-aws-vault/tree/master/examples/vault-consul-ami).
 
 ## Pre-requisites
+
+All the following commands to run are assumed to run in this `vault/` directory.
 
 ### Generate certificates
 
 You will need to have a TLS certificate generated for vault. This usually requires you to have
 generated an existing CA. Refer to
-[`ca`](ca/README.md) for instructions on how to setup a CA with the associated keys.
+[`ca`](../../ca/README.md) for instructions on how to setup a CA with the associated keys.
 
-For example, we will generate the certificate to the `cert` directory:
+For example, we will generate the certificate to the `vault/cert` directory:
 
 ```bash
 # Generate key pair and CSR
-cfssl genkey -config "../ca/config.json" \
-    -profile peer ../ca/vault-cert/csr.json \
+cfssl genkey -config "../../ca/config.json" \
+    -profile peer ../../ca/vault-cert/csr.json \
     | cfssljson -bare cert/cert
+```
+
+At this point, you must have decrypted the AWS-KMS encrypted CA private key (i.e. `ca.key` to
+`ca-key.pem`) so that the CA private key can be used to sign the CSR.
+
+Copy the true `ca.pem` and `ca.key` into `../../ca/root/` first, and perform the decryption step as
+shown in the
+[guide](../../ca/README.md#Decrypt-the-private-key). If the above two files are present, simply run
+the below adapted command to get back the original CA private key:
+
+```bash
+aws kms decrypt \
+    --ciphertext-blob fileb://../../ca/root/ca.key \
+    --output text \
+    --query Plaintext \
+    --cli-input-json file://../../ca/root/cli.json \
+| base64 --decode \
+> ../../ca/root/ca-key.pem
+```
+
+With the original CA private key in place, sign the CSR with the following:
+
+```bash
 # Sign the CSR
-cfssl sign -ca "../ca/root/ca.pem" \
-    -ca-key "../ca/root/ca-key.pem" \
-    -config "../ca/config.json" \
+cfssl sign -ca "../../ca/root/ca.pem" \
+    -ca-key "../../ca/root/ca-key.pem" \
+    -config "../../ca/config.json" \
     -profile peer \
     cert/cert.csr \
     | cfssljson -bare cert/cert
@@ -67,24 +93,33 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `aws_region`: AWS Region
 - `subnet_id`: ID of subnet to run the builder instance in
 - `temporary_security_group_source_cidr`: Temporary CIDR to allow SSH access from
-- `associate_public_ip_address`: Associate to `true` if the machine provisioned is to be connected via the internet
-- `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either the public IP address, private IP address, public DNS name or private DNS name will used as the host for SSH. The default behaviour if inside a VPC is to use the public IP address if available, otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
+- `associate_public_ip_address`: Associate to `true` if the machine provisioned is to be connected
+   via the internet
+- `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either
+   the public IP address, private IP address, public DNS name or private DNS name will used as the
+   host for SSH. The default behaviour if inside a VPC is to use the public IP address if available,
+   otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
 - `vault_version`: Version of Vault to install
-- `consul_module_version`: Version of the [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
-- `vault_module_version`: Version of the [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
+- `consul_module_version`: Version of the
+  [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
+- `vault_module_version`: Version of the
+  [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `vault_ui_enable`: Enable UI for Vault or not. Defaults to `true`.
 - `consul_version`: Version of Consul to install
 - `consul_key`: Key in Consul to store Vault HA information in
-- `tls_cert_file_src`: Path to the certificate file for Vault to use. This defaults to `cert/cert.pem` if you used the instructions above.
-- `encrypted_tls_key_file_src`: Encrypted private key for the certificate. This defaults to `cert/cert.key` if you used the instructions above.
-- `encrypted_aes_key_src`: AES data key used to encrypt the private key, which is in turned encrypted by AWS KMS. Defaults to `cert/aes.key` if you used the instructions above.
-- `cli_json_src`: The AWS CLI JSON file used to encrypt the AES key. This defaults to `cert/cli.json` if you used the instructions above.
-- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to empty to not install anything.
+- `tls_cert_file_src`: Path to the certificate file for Vault to use. This defaults to
+  `cert/cert.pem` if you used the instructions above.
+- `encrypted_tls_key_file_src`: Encrypted private key for the certificate. This defaults to
+  `cert/cert.key` if you used the instructions above.
+- `encrypted_aes_key_src`: AES data key used to encrypt the private key, which is in turned
+  encrypted by AWS KMS. Defaults to `cert/aes.key` if you used the instructions above.
+- `cli_json_src`: The AWS CLI JSON file used to encrypt the AES key. This defaults to
+  `cert/cli.json` if you used the instructions above.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
+  empty to not install anything.
 
 ## Building Image
 
 ```bash
-packer build \
-    -var-file=vars.json \
-    packer.json
+packer build packer.json
 ```


### PR DESCRIPTION
* Tweak commands with updated CA directory location
* Add some steps in between to help the README easier to follow
* Apply general 100 chars per line limit