### PR TITLE
Allow additional vars for td-agent

### DIFF
--- a/modules/core/packer/consul/README.md
+++ b/modules/core/packer/consul/README.md
@@ -38,12 +38,16 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
 - `consul_version`: Version of Consul to install
 - `td_agent_config_file`: Path to `td-agent` config file to template copy from. Install `td-agent`
   if path is non-empty.
+- `td_agent_config_vars_file`: Path to variables file to include for value interpolation for
+  `td-agent` config file. Only included if the value is not empty. `include_vars` includes the
+  variables into `config_vars` variable, i.e. if `xxx` value is defined in the variables file, you
+  will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
 
 ## Building Image
 
-If you have a `vars.json` variable file containing changes to the above variables, you may run:
+If you have a `vars.json` variables file containing changes to the above variables, you may run:
 
 ```bash
 packer build \

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -11,6 +11,7 @@
         "consul_module_version": "env-vars",
         "consul_version": "1.1.0",
         "td_agent_config_file": "",
+        "td_agent_config_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [
@@ -71,7 +72,7 @@
                 "-e",
                 "consul_module_version={{user `consul_module_version`}} consul_version={{user `consul_version`}} consul_module_repo={{user `consul_module_repo`}}",
                 "-e",
-                "td_agent_config_file={{user `td_agent_config_file`}}",
+                "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -6,6 +6,7 @@
     consul_module_version: "v0.1.0"
     consul_version: "1.1.0"
     td_agent_config_file: ""
+    td_agent_config_vars_file: ""
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -18,6 +19,7 @@
       name: "{{ playbook_dir }}/../roles/td-agent"
     vars:
       config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
   - name: Install Consul
     include_role:

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -40,12 +40,16 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `td_agent_config_file`: Path to `td-agent` config file to template copy from. Install `td-agent`
   if path is non-empty.
+- `td_agent_config_vars_file`: Path to variables file to include for value interpolation for
+  `td-agent` config file. Only included if the value is not empty. `include_vars` includes the
+  variables into `config_vars` variable, i.e. if `xxx` value is defined in the variables file, you
+  will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
 
 ## Building Image
 
-If you have a `vars.json` variable file containing changes to the above variables, you may run:
+If you have a `vars.json` variables file containing changes to the above variables, you may run:
 
 ```bash
 packer build \

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -15,6 +15,7 @@
         "vault_version": "0.10.1",
         "docker_version": "18.04.0~ce~3-0~ubuntu",
         "td_agent_config_file": "",
+        "td_agent_config_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [
@@ -86,7 +87,7 @@
                 "-e",
                 "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
                 "-e",
-                "td_agent_config_file={{user `td_agent_config_file`}}",
+                "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -10,6 +10,7 @@
     vault_version: "0.10.1"
     vault_module_version: "v0.4.0"
     td_agent_config_file: ""
+    td_agent_config_vars_file: ""
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -22,6 +23,7 @@
       name: "{{ playbook_dir }}/../roles/td-agent"
     vars:
       config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
   - name: Install pip3
     apt:

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -31,12 +31,16 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   [Vault Module](https://github.com/hashicorp/terraform-aws-vault) to use.
 - `td_agent_config_file`: Path to `td-agent` config file to template copy from. Install `td-agent`
   if path is non-empty.
+- `td_agent_config_vars_file`: Path to variables file to include for value interpolation for
+  `td-agent` config file. Only included if the value is not empty. `include_vars` includes the
+  variables into `config_vars` variable, i.e. if `xxx` value is defined in the variables file, you
+  will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
 
 ## Building Image
 
-If you have a `vars.json` variable file containing changes to the above variables, you may run:
+If you have a `vars.json` variables file containing changes to the above variables, you may run:
 
 ```bash
 packer build \

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -14,6 +14,7 @@
         "vault_module_version": "v0.5.1",
         "vault_version": "0.10.1",
         "td_agent_config_file": "",
+        "td_agent_config_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [
@@ -82,7 +83,7 @@
                 "-e",
                 "vault_version={{user `vault_version`}} vault_module_version={{user `vault_module_version`}}",
                 "-e",
-                "td_agent_config_file={{user `td_agent_config_file`}}",
+                "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -9,6 +9,7 @@
     vault_version: "0.10.1"
     vault_module_version: "v0.4.0"
     td_agent_config_file: ""
+    td_agent_config_vars_file: ""
     ca_certificate: ""
   pre_tasks:
   - name: Upgrade all packages to the latest version
@@ -21,6 +22,7 @@
       name: "{{ playbook_dir }}/../roles/td-agent"
     vars:
       config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
   - name: Install Consul
     include_role:

--- a/modules/core/packer/roles/td-agent/defaults/main.yml
+++ b/modules/core/packer/roles/td-agent/defaults/main.yml
@@ -2,3 +2,4 @@
 fluent_plugin_systemd_version: 1.0.0
 td_agent_tmp_file: /tmp/td-agent-install.sh
 config_file: ""
+config_vars_file: ""

--- a/modules/core/packer/roles/td-agent/tasks/main.yml
+++ b/modules/core/packer/roles/td-agent/tasks/main.yml
@@ -26,6 +26,11 @@
     groups: systemd-journal
     append: yes
   become: yes
+- name: Include configuration variables
+  include_vars:
+    file: "{{ config_vars_file }}"
+    name: config_vars
+  when: config_vars_file
 - name: Change td-agent configuration
   template:
     src: "{{ config_file }}"

--- a/modules/core/packer/roles/td-agent/tasks/main.yml
+++ b/modules/core/packer/roles/td-agent/tasks/main.yml
@@ -30,7 +30,7 @@
   include_vars:
     file: "{{ config_vars_file }}"
     name: config_vars
-  when: config_vars_file
+  when: config_vars_file != ""
 - name: Change td-agent configuration
   template:
     src: "{{ config_file }}"

--- a/modules/core/packer/vault/README.md
+++ b/modules/core/packer/vault/README.md
@@ -123,12 +123,16 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   `cert/cli.json` if you used the instructions above.
 - `td_agent_config_file`: Path to `td-agent` config file to template copy from. Install `td-agent`
   if path is non-empty.
+- `td_agent_config_vars_file`: Path to variables file to include for value interpolation for
+  `td-agent` config file. Only included if the value is not empty. `include_vars` includes the
+  variables into `config_vars` variable, i.e. if `xxx` value is defined in the variables file, you
+  will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
 
 ## Building Image
 
-If you have a `vars.json` variable file containing changes to the above variables, you may run:
+If you have a `vars.json` variables file containing changes to the above variables, you may run:
 
 ```bash
 packer build \

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -19,6 +19,7 @@
         "encrypted_aes_key_src": "{{ template_dir }}/cert/aes.key",
         "cli_json_src": "{{ template_dir }}/cert/cli.json",
         "td_agent_config_file": "",
+        "td_agent_config_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [
@@ -84,7 +85,7 @@
                 "-e",
                 "tls_cert_file_src={{user `tls_cert_file_src`}} encrypted_tls_key_file_src={{user `encrypted_tls_key_file_src`}} encrypted_aes_key_src={{user `encrypted_aes_key_src`}} cli_json_src={{user `cli_json_src`}}",
                 "-e",
-                "td_agent_config_file={{user `td_agent_config_file`}}",
+                "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -14,6 +14,7 @@
     encrypted_aes_key_src: "{{ playbook_dir }}/cert/aes.key"
     cli_json_src: "{{ playbook_dir }}/cert/cli.json"
     td_agent_config_file: ""
+    td_agent_config_vars_file: ""
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -26,6 +27,7 @@
       name: "{{ playbook_dir }}/../roles/td-agent"
     vars:
       config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
   - name: Install Consul
     include_role:


### PR DESCRIPTION
Provisions for optional vars file to include for value interpolation in `td-agent.conf`.