### PR TITLE
Add optional Telegraf installation for the big four

### DIFF
--- a/modules/core/outputs.tf
+++ b/modules/core/outputs.tf
@@ -191,6 +191,26 @@ output "internal_lb_https_listener_arn" {
   value = "${aws_lb_listener.internal_https.arn}"
 }
 
+output "consul_default_user_data" {
+  description = "Default launch configuration user data for Consul"
+  value       = "${data.template_file.user_data_consul.rendered}"
+}
+
+output "nomad_client_default_user_data" {
+  description = "Default launch configuration user data for Nomad Client"
+  value       = "${data.template_file.user_data_nomad_client.rendered}"
+}
+
+output "nomad_server_default_user_data" {
+  description = "Default launch configuration user data for Nomad Server"
+  value       = "${data.template_file.user_data_nomad_server.rendered}"
+}
+
+output "vault_default_user_data" {
+  description = "Default launch configuration user data for Vault"
+  value       = "${data.template_file.user_data_vault.rendered}"
+}
+
 output "ssh_key_name" {
   value = "${var.ssh_key_name}"
 }

--- a/modules/core/outputs.tf
+++ b/modules/core/outputs.tf
@@ -191,9 +191,9 @@ output "internal_lb_https_listener_arn" {
   value = "${aws_lb_listener.internal_https.arn}"
 }
 
-output "consul_default_user_data" {
-  description = "Default launch configuration user data for Consul"
-  value       = "${data.template_file.user_data_consul.rendered}"
+output "consul_server_default_user_data" {
+  description = "Default launch configuration user data for Consul Server"
+  value       = "${data.template_file.user_data_consul_server.rendered}"
 }
 
 output "nomad_client_default_user_data" {
@@ -206,9 +206,9 @@ output "nomad_server_default_user_data" {
   value       = "${data.template_file.user_data_nomad_server.rendered}"
 }
 
-output "vault_default_user_data" {
-  description = "Default launch configuration user data for Vault"
-  value       = "${data.template_file.user_data_vault.rendered}"
+output "vault_cluster_default_user_data" {
+  description = "Default launch configuration user data for Vault Cluster"
+  value       = "${data.template_file.user_data_vault_cluster.rendered}"
 }
 
 output "ssh_key_name" {

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -13,6 +13,9 @@
         "consul_enable_syslog": "true",
         "td_agent_config_file": "",
         "td_agent_config_vars_file": "",
+        "telegraf_config_file": "",
+        "telegraf_config_vars_file": "",
+        "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
         "ca_certificate": ""
     },
     "builders": [
@@ -76,6 +79,8 @@
                 "{ \"consul_enable_syslog\": {{user `consul_enable_syslog`}} }",
                 "-e",
                 "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+                "-e",
+                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -8,6 +8,9 @@
     consul_enable_syslog: true
     td_agent_config_file: ""
     td_agent_config_vars_file: ""
+    telegraf_config_file: ""
+    telegraf_config_vars_file: ""
+    telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -22,6 +25,14 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
+  - name: Install telegraf with custom configuration
+    include_role:
+      name: "{{ playbook_dir }}/../roles/telegraf"
+    vars:
+      config_file: "{{ telegraf_config_file }}"
+      config_vars_file: "{{ telegraf_config_vars_file }}"
+      config_dest_file: "{{ telegraf_config_dest_file }}"
+    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -36,6 +36,9 @@
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"
+  - name: Install Consul-Template
+    include_role:
+      name: "{{ playbook_dir }}/../roles/install-consul-template"
   - name: Install CA Certificate
     include_role:
       name: "{{ playbook_dir }}/../roles/ansible-ca-store"

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -25,14 +25,13 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
-  - name: Install telegraf with custom configuration
+  - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../roles/telegraf"
     vars:
       config_file: "{{ telegraf_config_file }}"
       config_vars_file: "{{ telegraf_config_vars_file }}"
       config_dest_file: "{{ telegraf_config_dest_file }}"
-    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -18,6 +18,8 @@
         "nomad_enable_syslog": "true",
         "td_agent_config_file": "",
         "td_agent_config_vars_file": "",
+        "telegraf_config_file": "",
+        "telegraf_config_file_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [
@@ -92,6 +94,8 @@
                 "{ \"consul_enable_syslog\": {{user `consul_enable_syslog`}}, \"nomad_enable_syslog\": {{user `nomad_enable_syslog`}} }",
                 "-e",
                 "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+                "-e",
+                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -19,7 +19,7 @@
         "td_agent_config_file": "",
         "td_agent_config_vars_file": "",
         "telegraf_config_file": "",
-        "telegraf_config_file_vars_file": "",
+        "telegraf_config_vars_file": "",
         "ca_certificate": ""
     },
     "builders": [

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -20,6 +20,7 @@
         "td_agent_config_vars_file": "",
         "telegraf_config_file": "",
         "telegraf_config_vars_file": "",
+        "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
         "ca_certificate": ""
     },
     "builders": [
@@ -95,7 +96,7 @@
                 "-e",
                 "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
                 "-e",
-                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}}",
+                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -13,6 +13,8 @@
     nomad_enable_syslog: true
     td_agent_config_file: ""
     td_agent_config_vars_file: ""
+    telegraf_config_file: ""
+    telegraf_config_file_vars_file: ""
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -27,6 +29,13 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
+  - name: Install telegraf with custom configuration
+    include_role:
+      name: "{{ playbook_dir }}/../roles/telegraf"
+    vars:
+      config_file: "{{ telegraf_config_file }}"
+      config_vars_file: "{{ telegraf_config_vars_file }}"
+    when: telegraf_config_file
   - name: Install pip3
     apt:
       name: python3-pip

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -14,7 +14,7 @@
     td_agent_config_file: ""
     td_agent_config_vars_file: ""
     telegraf_config_file: ""
-    telegraf_config_file_vars_file: ""
+    telegraf_config_vars_file: ""
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -15,6 +15,7 @@
     td_agent_config_vars_file: ""
     telegraf_config_file: ""
     telegraf_config_vars_file: ""
+    telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -35,6 +36,7 @@
     vars:
       config_file: "{{ telegraf_config_file }}"
       config_vars_file: "{{ telegraf_config_vars_file }}"
+      config_dest_file: "{{ telegraf_config_dest_file }}"
     when: telegraf_config_file
   - name: Install pip3
     apt:

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -30,14 +30,13 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
-  - name: Install telegraf with custom configuration
+  - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../roles/telegraf"
     vars:
       config_file: "{{ telegraf_config_file }}"
       config_vars_file: "{{ telegraf_config_vars_file }}"
       config_dest_file: "{{ telegraf_config_dest_file }}"
-    when: telegraf_config_file
   - name: Install pip3
     apt:
       name: python3-pip

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -17,6 +17,9 @@
         "nomad_enable_syslog": "true",
         "td_agent_config_file": "",
         "td_agent_config_vars_file": "",
+        "telegraf_config_file": "",
+        "telegraf_config_vars_file": "",
+        "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
         "ca_certificate": ""
     },
     "builders": [
@@ -88,6 +91,8 @@
                 "{ \"consul_enable_syslog\": {{user `consul_enable_syslog`}}, \"nomad_enable_syslog\": {{user `nomad_enable_syslog`}} }",
                 "-e",
                 "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+                "-e",
+                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -12,6 +12,9 @@
     nomad_enable_syslog: true
     td_agent_config_file: ""
     td_agent_config_vars_file: ""
+    telegraf_config_file: ""
+    telegraf_config_vars_file: ""
+    telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
   pre_tasks:
   - name: Upgrade all packages to the latest version
@@ -26,6 +29,14 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
+  - name: Install telegraf with custom configuration
+    include_role:
+      name: "{{ playbook_dir }}/../roles/telegraf"
+    vars:
+      config_file: "{{ telegraf_config_file }}"
+      config_vars_file: "{{ telegraf_config_vars_file }}"
+      config_dest_file: "{{ telegraf_config_dest_file }}"
+    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -29,14 +29,13 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
-  - name: Install telegraf with custom configuration
+  - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../roles/telegraf"
     vars:
       config_file: "{{ telegraf_config_file }}"
       config_vars_file: "{{ telegraf_config_vars_file }}"
       config_dest_file: "{{ telegraf_config_dest_file }}"
-    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/packer/roles/consul/meta/main.yml
+++ b/modules/core/packer/roles/consul/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - { role: "install-consul-template" }

--- a/modules/core/packer/roles/consul/meta/main.yml
+++ b/modules/core/packer/roles/consul/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "install-consul-template" }

--- a/modules/core/packer/roles/install-consul-template/files/run-consul-template.sh
+++ b/modules/core/packer/roles/install-consul-template/files/run-consul-template.sh
@@ -188,7 +188,7 @@ function generate_base_config {
 
 
   local dedup_config=""
-  if [[ "$dedup_enable" == true && ! -z "$dedup_prefix" ]]; then
+  if [[ "$dedup_enable" == "true" && ! -z "$dedup_prefix" ]]; then
     dedup_config=$(cat <<EOF
 deduplicate {
   enabled = true

--- a/modules/core/packer/roles/install-consul-template/tasks/main.yml
+++ b/modules/core/packer/roles/install-consul-template/tasks/main.yml
@@ -18,7 +18,7 @@
     group: "{{ consul_template_user }}"
     owner: "{{ consul_template_user }}"
     state: directory
-  loop:
+  with_items:
     - "{{ base_path }}"
     - "{{ base_path }}/bin"
     - "{{ base_path }}/config"

--- a/modules/core/packer/roles/td-agent/README.md
+++ b/modules/core/packer/roles/td-agent/README.md
@@ -3,7 +3,9 @@
 This role ensures that `td-agent` is installed on the target machine.
 
 You are required to provide your own configuration for `td-agent`, given as a path to Ansible
-playbook variable `config_file`.
+playbook variable `config_file`. Note that `config_file` is copied into`/etc/td-agent/td-agent.conf`
+by an Ansible template copy, and the var file can be optionally provided to
+`config_vars_file` for the template copy.
 
 See <https://www.fluentd.org/faqs> to check the difference between `td-agent`
 and `fluentd`.

--- a/modules/core/packer/roles/telegraf/README.md
+++ b/modules/core/packer/roles/telegraf/README.md
@@ -1,0 +1,6 @@
+# telegraf
+
+This role ensures that `telegraf` is installed on the target machine.
+
+You are required to provide your own configuration for `telegraf`, given as a path to Ansible
+playbook variable `config_file`.

--- a/modules/core/packer/roles/telegraf/README.md
+++ b/modules/core/packer/roles/telegraf/README.md
@@ -3,4 +3,6 @@
 This role ensures that `telegraf` is installed on the target machine.
 
 You are required to provide your own configuration for `telegraf`, given as a path to Ansible
-playbook variable `config_file`.
+playbook variable `config_file`. Note that `config_file` is copied into `config_dest_file` by an
+Ansible template copy, and the var file can be optionally provided to `config_vars_file` for the
+template copy.

--- a/modules/core/packer/roles/telegraf/defaults/main.yml
+++ b/modules/core/packer/roles/telegraf/defaults/main.yml
@@ -2,3 +2,4 @@
 telegraf_version: 1.6.4
 config_file: ""
 config_vars_file: ""
+config_dest_file: "/etc/telegraf/telegraf.conf"

--- a/modules/core/packer/roles/telegraf/defaults/main.yml
+++ b/modules/core/packer/roles/telegraf/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+telegraf_version: 1.6.4
+config_file: ""
+config_vars_file: ""

--- a/modules/core/packer/roles/telegraf/files/run-telegraf.sh
+++ b/modules/core/packer/roles/telegraf/files/run-telegraf.sh
@@ -176,7 +176,7 @@ function main {
   if [[ "$enabled" != "yes" ]]; then
     log_info "Telegraf is not enabled"
   else
-    if [[ "$skip_template" == "false" && -f "$conf_template" ]]
+    if [[ "$skip_template" == "false" && -f "$conf_template" ]]; then
       consul-template -template "$conf_template:$conf_out" -once
     fi
 

--- a/modules/core/packer/roles/telegraf/files/run-telegraf.sh
+++ b/modules/core/packer/roles/telegraf/files/run-telegraf.sh
@@ -181,7 +181,7 @@ function main {
     fi
 
     mkdir -p "$service_override_dir"
-    echo -e "[Service]\nEnvironment=SERVICE=$type" > "$service_override_dir/override.conf"
+    echo -e "[Service]\nEnvironment=SERVICE_NAME=$type" > "$service_override_dir/override.conf"
 
     systemctl enable telegraf
     systemctl start telegraf

--- a/modules/core/packer/roles/telegraf/files/run-telegraf.sh
+++ b/modules/core/packer/roles/telegraf/files/run-telegraf.sh
@@ -135,9 +135,7 @@ function main {
         shift
         ;;
       --skip-template)
-        assert_not_empty "$key" "$2"
-        skip_template="$2"
-        shift
+        skip_template="false"
         ;;
       --conf-template)
         assert_not_empty "$key" "$2"
@@ -178,7 +176,7 @@ function main {
   if [[ "$enabled" != "yes" ]]; then
     log_info "Telegraf is not enabled"
   else
-    if [[ "$skip_template" != "true" ]]
+    if [[ "$skip_template" == "false" && -f "$conf_template" ]]
       consul-template -template "$conf_template:$conf_out" -once
     fi
 

--- a/modules/core/packer/roles/telegraf/files/run-telegraf.sh
+++ b/modules/core/packer/roles/telegraf/files/run-telegraf.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Note: This script works assumes that the non-configurable defaults setup by the Ansible roles
+# and the `core` and `vault-ssh` modules are not changed. Otherwise, it will fail to
+# find the right values and will not work.
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "$0")"
+
+readonly MAX_RETRIES=30
+readonly SLEEP_BETWEEN_RETRIES_SEC=10
+
+function print_usage {
+  echo
+  echo "Usage: run-telegraf [OPTIONS]"
+  echo
+  echo "This script is used to configure Telegraf on an AWS server."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --type\t\tThe type of instance being configured. Required. Can be 'consul', 'vault', 'nomad_client' or 'nomad_server'."
+  echo -e "  --consul-prefix\t\tPath prefix in Consul KV store to query for integration status. Optional. Defaults to terraform/"
+  echo -e "  --skip-template\t\tEnable consul-template apply on configuration file. Optional. Defaults to false."
+  echo -e "  --conf-template\t\tFile path to configuration consul-template file. Optional. Defaults to /etc/telegraf/telegraf.conf.template"
+  echo -e "  --conf-out\t\tFile path to configuration destination. Optional. Defaults to /etc/telegraf/telegraf.conf"
+  echo
+  echo "Example:"
+  echo
+  echo "  run-telegraf --type consul"
+}
+
+function log {
+  local readonly level="$1"
+  local readonly message="$2"
+  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
+}
+
+function log_info {
+  local readonly message="$1"
+  log "INFO" "${message}"
+}
+
+function log_warn {
+  local readonly message="$1"
+  log "WARN" "${message}"
+}
+
+function log_error {
+  local readonly message="$1"
+  log "ERROR" "${message}"
+}
+
+function assert_not_empty {
+  local readonly arg_name="$1"
+  local readonly arg_value="$2"
+
+  if [[ -z "${arg_value}" ]]; then
+    log_error "The value for '${arg_name}' cannot be empty"
+    print_usage
+    exit 1
+  fi
+}
+
+function assert_is_installed {
+  local readonly name="$1"
+
+  if [[ ! $(command -v ${name}) ]]; then
+    log_error "The binary '${name}' is required by this script but is not installed or in the system's PATH."
+    exit 1
+  fi
+}
+
+function wait_for_consul {
+  local consul_leader
+
+  for (( i=1; i<="$MAX_RETRIES"; i++ )); do
+    consul_leader=$(
+      curl -sS http://localhost:8500/v1/status/leader 2> /dev/null || echo "failed"
+    )
+
+    if [[ "${consul_leader}" = "failed" ]]; then
+      log_warn "Failed to find Consul cluster leader. Will sleep for $SLEEP_BETWEEN_RETRIES_SEC seconds and try again."
+      sleep "$SLEEP_BETWEEN_RETRIES_SEC"
+    else
+      log_info "Found Consul leader at ${consul_leader}"
+      return
+    fi
+  done
+
+  log_error "Failed to detect Consul agent after $MAX_RETRIES retries. Did you start a Consul agent before running the script?"
+  exit 1
+}
+
+
+function consul_kv {
+  local readonly path="${1}"
+  local value
+  value=$(consul kv get "${path}") || exit $?
+  log_info "Consul KV Path ${path} = ${value}"
+  echo -n "${value}"
+}
+
+function consul_kv_with_default {
+  local readonly path="${1}"
+  local readonly default="${2}"
+  local value
+  value=$(consul kv get "${path}" || echo -n "${default}") || exit $?
+  log_info "Consul KV Path ${path} = ${value}"
+  echo -n "${value}"
+}
+
+function main {
+  local type=""
+  local consul_prefix="terraform/"
+  local skip_template="false"
+  local conf_template="/etc/telegraf/telegraf.conf.template"
+  local conf_out="/etc/telegraf/telegraf.conf"
+
+  local readonly service_override_dir="/etc/systemd/system/telegraf.service.d"
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --type)
+        assert_not_empty "$key" "$2"
+        type="$2"
+        shift
+        ;;
+      --consul-prefix)
+        assert_not_empty "$key" "$2"
+        consul_prefix="$2"
+        shift
+        ;;
+      --skip-template)
+        assert_not_empty "$key" "$2"
+        skip_template="$2"
+        shift
+        ;;
+      --conf-template)
+        assert_not_empty "$key" "$2"
+        conf_template="$2"
+        shift
+        ;;
+      --conf-out)
+        assert_not_empty "$key" "$2"
+        conf_out="$2"
+        shift
+        ;;
+      --help)
+        print_usage
+        exit
+        ;;
+      *)
+        log_error "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  if [[ "$type" != "vault" && "$type" != "consul" && "$type" != "nomad_server" && "$type" != "nomad_client" ]]; then
+    log_error "Invalid type set."
+    exit 1
+  fi
+
+  assert_is_installed "consul"
+  assert_is_installed "consul-template"
+
+  wait_for_consul
+
+  local readonly enabled=$(consul_kv_with_default "${consul_prefix}telegraf/enabled" "no")
+
+  if [[ "$enabled" != "yes" ]]; then
+    log_info "Telegraf is not enabled"
+  else
+    if [[ "$skip_template" != "true" ]]
+      consul-template -template "$conf_template:$conf_out" -once
+    fi
+
+    mkdir -p "$service_override_dir"
+    echo -e "[Service]\nEnvironment=SERVICE=$type" > "$service_override_dir/override.conf"
+
+    systemctl enable telegraf
+    systemctl start telegraf
+  fi
+}
+
+main "$@"

--- a/modules/core/packer/roles/telegraf/tasks/main.yml
+++ b/modules/core/packer/roles/telegraf/tasks/main.yml
@@ -15,6 +15,12 @@
     mode: 0644
   when: config_file != ""
   become: yes
+- name: Install configuration script
+  copy:
+    src: "{{ role_path }}/files/run-telegraf.sh"
+    dest: "/opt/run-telegraf"
+    mode: 0755
+  become: yes
 - name: Disable the telegraf service for next configuration set-up
   service:
     name: telegraf

--- a/modules/core/packer/roles/telegraf/tasks/main.yml
+++ b/modules/core/packer/roles/telegraf/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install telegraf deb file
+  apt:
+    deb: "https://dl.influxdata.com/telegraf/releases/telegraf_{{ telegraf_version }}-1_amd64.deb"
+  become: yes
+- name: Include configuration variables
+  include_vars:
+    file: "{{ config_vars_file }}"
+    name: config_vars
+  when: config_vars_file != ""
+- name: Change telegraf configuration
+  template:
+    src: "{{ config_file }}"
+    dest: "/etc/telegraf/telegraf.conf"
+    mode: 0644
+  become: yes
+- name: Enable the telegraf service for next boot-up
+  service:
+    name: telegraf
+    enabled: yes
+    use: service
+  become: yes

--- a/modules/core/packer/roles/telegraf/tasks/main.yml
+++ b/modules/core/packer/roles/telegraf/tasks/main.yml
@@ -13,10 +13,11 @@
     src: "{{ config_file }}"
     dest: "{{ config_dest_file }}"
     mode: 0644
+  when: config_file != ""
   become: yes
-- name: Enable the telegraf service for next boot-up
+- name: Disable the telegraf service for next configuration set-up
   service:
     name: telegraf
-    enabled: yes
+    enabled: no
     use: service
   become: yes

--- a/modules/core/packer/roles/telegraf/tasks/main.yml
+++ b/modules/core/packer/roles/telegraf/tasks/main.yml
@@ -8,7 +8,7 @@
     file: "{{ config_vars_file }}"
     name: config_vars
   when: config_vars_file != ""
-- name: Change telegraf configuration
+- name: Copy Telegraf configuration
   template:
     src: "{{ config_file }}"
     dest: "{{ config_dest_file }}"

--- a/modules/core/packer/roles/telegraf/tasks/main.yml
+++ b/modules/core/packer/roles/telegraf/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Change telegraf configuration
   template:
     src: "{{ config_file }}"
-    dest: "/etc/telegraf/telegraf.conf"
+    dest: "{{ config_dest_file }}"
     mode: 0644
   become: yes
 - name: Enable the telegraf service for next boot-up

--- a/modules/core/packer/roles/vault/meta/main.yml
+++ b/modules/core/packer/roles/vault/meta/main.yml
@@ -4,4 +4,3 @@ dependencies:
   - { role: "aws-cli" }
   - { role: "ansible" }
   - { role: "install-kms-aes" }
-  - { role: "install-consul-template" }

--- a/modules/core/packer/roles/vault/meta/main.yml
+++ b/modules/core/packer/roles/vault/meta/main.yml
@@ -4,3 +4,4 @@ dependencies:
   - { role: "aws-cli" }
   - { role: "ansible" }
   - { role: "install-kms-aes" }
+  - { role: "install-consul-template" }

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -21,6 +21,9 @@
         "consul_enable_syslog": "true",
         "td_agent_config_file": "",
         "td_agent_config_vars_file": "",
+        "telegraf_config_file": "",
+        "telegraf_config_vars_file": "",
+        "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
         "ca_certificate": ""
     },
     "builders": [
@@ -89,6 +92,8 @@
                 "tls_cert_file_src={{user `tls_cert_file_src`}} encrypted_tls_key_file_src={{user `encrypted_tls_key_file_src`}} encrypted_aes_key_src={{user `encrypted_aes_key_src`}} cli_json_src={{user `cli_json_src`}}",
                 "-e",
                 "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+                "-e",
+                "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -33,14 +33,13 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
-  - name: Install telegraf with custom configuration
+  - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../roles/telegraf"
     vars:
       config_file: "{{ telegraf_config_file }}"
       config_vars_file: "{{ telegraf_config_vars_file }}"
       config_dest_file: "{{ telegraf_config_dest_file }}"
-    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -44,6 +44,9 @@
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"
+  - name: Install Consul-Template
+    include_role:
+      name: "{{ playbook_dir }}/../roles/install-consul-template"
   - name: Install Vault
     include_role:
       name: "{{ playbook_dir }}/../roles/vault"

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -16,6 +16,9 @@
     cli_json_src: "{{ playbook_dir }}/cert/cli.json"
     td_agent_config_file: ""
     td_agent_config_vars_file: ""
+    telegraf_config_file: ""
+    telegraf_config_vars_file: ""
+    telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
   tasks:
   - name: Upgrade all packages to the latest version
@@ -30,6 +33,14 @@
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
     when: td_agent_config_file
+  - name: Install telegraf with custom configuration
+    include_role:
+      name: "{{ playbook_dir }}/../roles/telegraf"
+    vars:
+      config_file: "{{ telegraf_config_file }}"
+      config_vars_file: "{{ telegraf_config_vars_file }}"
+      config_dest_file: "{{ telegraf_config_dest_file }}"
+    when: telegraf_config_file
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../roles/consul"

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -26,9 +26,3 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "consul"
-
-# To fix up the Elasticsearch DNS at runtime for Telegraf config
-consul-template -template \
-    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
-
-sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -19,3 +19,9 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "consul"
+
+# To fix up the Elasticsearch DNS at runtime for Telegraf config
+consul-template -template \
+    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
+
+sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -26,3 +26,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "consul"
+
+/opt/run-telegraf \
+    --type "nomad_client"

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -16,6 +16,13 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --cluster-tag-value "${cluster_tag_value}" \
     --environment "CONSUL_UI_BETA=\"true\""
 
+# Configure and run consul-template
+/opt/consul-template/bin/run-consul-template \
+    --server-type nomad_client \
+    --dedup-enable \
+    --syslog-enable \
+    --consul-prefix "${consul_prefix}"
+
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "consul"

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -28,4 +28,4 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --type "consul"
 
 /opt/run-telegraf \
-    --type "nomad_client"
+    --type "consul"

--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -18,7 +18,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 # Configure and run consul-template
 /opt/consul-template/bin/run-consul-template \
-    --server-type nomad_client \
+    --server-type consul \
     --dedup-enable \
     --syslog-enable \
     --consul-prefix "${consul_prefix}"

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -33,9 +33,3 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_client"
-
-# To fix up the Elasticsearch DNS at runtime for Telegraf config
-consul-template -template \
-    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
-
-sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -33,3 +33,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_client"
+
+/opt/run-telegraf \
+    --type "nomad_client"

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -37,3 +37,5 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 # To fix up the Elasticsearch DNS at runtime for Telegraf config
 consul-template -template \
     "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
+
+sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -33,3 +33,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_client"
+
+# To fix up the Elasticsearch DNS at runtime for Telegraf config
+consul-template -template \
+    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -33,3 +33,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_server"
+
+/opt/run-telegraf \
+    --type "nomad_server"

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -33,3 +33,9 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_server"
+
+# To fix up the Elasticsearch DNS at runtime for Telegraf config
+consul-template -template \
+    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
+
+sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -33,9 +33,3 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "nomad_server"
-
-# To fix up the Elasticsearch DNS at runtime for Telegraf config
-consul-template -template \
-    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
-
-sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -28,6 +28,13 @@ AWS_DEFAULT_REGION="${aws_region}" \
     --cluster-tag-key "${consul_cluster_tag_key}" \
     --cluster-tag-value "${consul_cluster_tag_value}"
 
+# Configure and run consul-template
+/opt/consul-template/bin/run-consul-template \
+    --server-type nomad_client \
+    --dedup-enable \
+    --syslog-enable \
+    --consul-prefix "${consul_prefix}"
+
 # The Packer template puts the TLS certs in these file paths
 readonly VAULT_TLS_CERT_FILE="${cert_file}"
 readonly VAULT_TLS_KEY_FILE="${cert_key}"

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -49,3 +49,9 @@ fi
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "vault"
+
+# To fix up the Elasticsearch DNS at runtime for Telegraf config
+consul-template -template \
+    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
+
+sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -30,7 +30,7 @@ AWS_DEFAULT_REGION="${aws_region}" \
 
 # Configure and run consul-template
 /opt/consul-template/bin/run-consul-template \
-    --server-type nomad_client \
+    --server-type vault \
     --dedup-enable \
     --syslog-enable \
     --consul-prefix "${consul_prefix}"

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -56,9 +56,3 @@ fi
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "vault"
-
-# To fix up the Elasticsearch DNS at runtime for Telegraf config
-consul-template -template \
-    "/etc/telegraf/telegraf.conf.template:/etc/telegraf/telegraf.conf" -once
-
-sudo systemctl restart telegraf.service

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -56,3 +56,6 @@ fi
 /opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "vault"
+
+/opt/run-telegraf \
+    --type "vault"

--- a/modules/telegraf/README.md
+++ b/modules/telegraf/README.md
@@ -1,0 +1,35 @@
+# Telegraf module
+
+This module allows enabling of `telegraf` service for metrics reporting. Meant to be used in
+instances containing services `consul`, `nomad_client`, `nomad_server` and `vault`.
+
+## Integration with `Core` module
+
+This module is integrated with the `core` module to enable you to use both in conjunction
+seamlessly.
+
+## Example usage
+
+```hcl
+...
+
+module "telegraf" {
+  source = "../../../vendor/terraform-modules/modules/telegraf"
+
+  # Optional, default is true
+  core_integration = true
+
+  # Optional, default is terraform/
+  consul_key_prefix = "terraform/"
+}
+
+...
+```
+
+You should copy your Telegraf configuration file into `/etc/telegraf/telegraf.conf`, and run
+`/opt/run-telegraf --type <service_type>` in the user data to start the service with the custom
+configuration.
+
+If you wish to apply interpolation from `consul-template`, you may instead copy the configuration
+file to `/etc/telegraf/telegraf.conf.template`. `run-telegraf` will automatically detect this file
+and apply template interpolation, unless `--skip-template` is explicitly set for `run-telegraf`.

--- a/modules/telegraf/main.tf
+++ b/modules/telegraf/main.tf
@@ -3,7 +3,8 @@ resource "consul_key_prefix" "core_integration" {
   path_prefix = "${var.consul_key_prefix}telegraf/"
 
   subkeys {
-    "enabled" = "yes"
-    "README"  = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
+    "enabled"     = "yes"
+    "README"      = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
+    "init_script" = "${var.init_script}"
   }
 }

--- a/modules/telegraf/main.tf
+++ b/modules/telegraf/main.tf
@@ -1,0 +1,9 @@
+resource "consul_key_prefix" "core_integration" {
+  count       = "${var.core_integration ? 1 : 0}"
+  path_prefix = "${var.consul_key_prefix}telegraf/"
+
+  subkeys {
+    "enabled" = "yes"
+    "README"  = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
+  }
+}

--- a/modules/telegraf/main.tf
+++ b/modules/telegraf/main.tf
@@ -3,8 +3,7 @@ resource "consul_key_prefix" "core_integration" {
   path_prefix = "${var.consul_key_prefix}telegraf/"
 
   subkeys {
-    "enabled"     = "yes"
-    "README"      = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
-    "init_script" = "${var.init_script}"
+    "enabled" = "yes"
+    "README"  = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
   }
 }

--- a/modules/telegraf/variables.tf
+++ b/modules/telegraf/variables.tf
@@ -1,16 +1,4 @@
 # --------------------------------------------------------------------------------------------------
-# OPTIONAL PARAMETERS
-# These parameters have reasonable defaults.
-# --------------------------------------------------------------------------------------------------
-variable "init_script" {
-  description = <<EOF
-        Initialisation script command(s) to run. Assumes no additional script required to set-up.
-EOF
-
-  default = ""
-}
-
-# --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------
 variable "core_integration" {

--- a/modules/telegraf/variables.tf
+++ b/modules/telegraf/variables.tf
@@ -1,0 +1,33 @@
+# --------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# --------------------------------------------------------------------------------------------------
+variable "init_script" {
+  description = <<EOF
+        Initialisation script command(s) to run. Assumes no additional script required to set-up.
+EOF
+
+  default = ""
+}
+
+# --------------------------------------------------------------------------------------------------
+# CORE INTEGRATION SETTINGS
+# --------------------------------------------------------------------------------------------------
+variable "core_integration" {
+  description = <<EOF
+        Enable integration with the `core` module by setting some values in Consul so
+        that the user_data scripts in core know that this module has been applied
+EOF
+
+  default = true
+}
+
+variable "consul_key_prefix" {
+  description = <<EOF
+        Path prefix to the key in Consul to set for the `core` module to know that this module has
+        been applied. If you change this, you have to update the
+        `integration_consul_prefix` variable in the core module as well.
+EOF
+
+  default = "terraform/"
+}


### PR DESCRIPTION
- Similar idea to the previous `td-agent`, must provide config file to enable installation of `telegraf`.
- Add `consul-template` to Vault and Consul, meant for allowing interpolation of secrets at runtime even for these two.
- Provide outputs for the default user data, which can be used for string concatenation trick at deriving modules to provide additional appended script commands.