### PR TITLE
Add "additional" variables to Nomad Packer Templates

### DIFF
--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -46,7 +46,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is.
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. Define the list as a single comma-separated string and Packer will automatically [turn it into an array](https://www.packer.io/docs/templates/user-variables.html#using-array-values).
 
 ## Building Image
 

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -46,7 +46,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. Define the list as a single comma-separated string and Packer will automatically [turn it into an array](https://www.packer.io/docs/templates/user-variables.html#using-array-values).
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. The variable will be passed as-is to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. See this [page](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line) for information on how to format the list.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -46,7 +46,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. The variable will be passed as-is to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. See this [page](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line) for information on how to format the list.
+- `extra_vars`: Additional variables to pass to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. This is useful for additional variables that are available in the Ansible playbooks used to provision the packer images.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_clients/README.md
+++ b/modules/core/packer/nomad_clients/README.md
@@ -46,6 +46,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -22,7 +22,7 @@
         "telegraf_config_vars_file": "",
         "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
         "ca_certificate": "",
-        "nomad_additional_config": ""
+        "extra_vars": "{}"
     },
     "builders": [
         {
@@ -101,9 +101,9 @@
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",
-                "nomad_additional_config={{user `nomad_additional_config` }}",
+                "ansible_python_interpreter=/usr/bin/python3",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3"
+                "{{user `extra_vars` }}"
             ]
         }
     ]

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -21,7 +21,8 @@
         "telegraf_config_file": "",
         "telegraf_config_vars_file": "",
         "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
-        "ca_certificate": ""
+        "ca_certificate": "",
+        "nomad_additional_config": ""
     },
     "builders": [
         {
@@ -99,6 +100,8 @@
                 "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
+                "-e",
+                "nomad_additional_config={{user `nomad_additional_config` }}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -17,6 +17,7 @@
     telegraf_config_vars_file: ""
     telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
+    nomad_additional_config: []
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -37,6 +37,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -37,7 +37,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is.
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. Define the list as a single comma-separated string and Packer will automatically [turn it into an array](https://www.packer.io/docs/templates/user-variables.html#using-array-values).
 
 ## Building Image
 

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -37,7 +37,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. Define the list as a single comma-separated string and Packer will automatically [turn it into an array](https://www.packer.io/docs/templates/user-variables.html#using-array-values).
+- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. The variable will be passed as-is to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. See this [page](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line) for information on how to format the list.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_servers/README.md
+++ b/modules/core/packer/nomad_servers/README.md
@@ -37,7 +37,7 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
-- `nomad_additional_config`: List of path to additional configuration files to copy over to Nomad's configuration directory. The file names will be kept as-is. The variable will be passed as-is to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. See this [page](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#passing-variables-on-the-command-line) for information on how to format the list.
+- `extra_vars`: Additional variables to pass to Ansible via the [`-e`](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html#cmdoption-ansible-playbook-e) flag. This is useful for additional variables that are available in the Ansible playbooks used to provision the packer images.
 
 ## Building Image
 

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -97,9 +97,9 @@
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
                 "-e",
-                "nomad_additional_config={{user `nomad_additional_config` }}",
+                "ansible_python_interpreter=/usr/bin/python3",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3"
+                "{{user `extra_vars` }}"
             ]
         }
     ]

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -20,7 +20,8 @@
         "telegraf_config_file": "",
         "telegraf_config_vars_file": "",
         "telegraf_config_dest_file": "/etc/telegraf/telegraf.conf",
-        "ca_certificate": ""
+        "ca_certificate": "",
+        "nomad_additional_config": ""
     },
     "builders": [
         {
@@ -95,6 +96,8 @@
                 "telegraf_config_file={{user `telegraf_config_file`}} telegraf_config_vars_file={{user `telegraf_config_vars_file`}} telegraf_config_dest_file={{user `telegraf_config_dest_file`}}",
                 "-e",
                 "ca_certificate={{user `ca_certificate`}}",
+                "-e",
+                "nomad_additional_config={{user `nomad_additional_config` }}",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -16,6 +16,7 @@
     telegraf_config_vars_file: ""
     telegraf_config_dest_file: "/etc/telegraf/telegraf.conf"
     ca_certificate: ""
+    nomad_additional_config: []
   pre_tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/core/packer/roles/nomad/defaults/main.yml
+++ b/modules/core/packer/roles/nomad/defaults/main.yml
@@ -6,3 +6,4 @@
   nomad_user: "nomad"
   consul_template_user: "root"
   nomad_enable_syslog: true
+  nomad_additional_config: []

--- a/modules/core/packer/roles/nomad/tasks/main.yml
+++ b/modules/core/packer/roles/nomad/tasks/main.yml
@@ -15,15 +15,24 @@
   copy:
     src: "{{ role_path }}/files/config/"
     dest: "/opt/nomad/config"
+    owner: "{{ nomad_user }}"
   become: yes
 - name: "Copy Nomad template sub-configurations"
   template:
     src: "{{ role_path }}/files/templates/{{ item }}"
     dest: "/opt/nomad/config/{{ item }}"
+    owner: "{{ nomad_user }}"
   vars:
     enable_syslog: "{{ nomad_enable_syslog }}"
   with_items:
   - syslog.hcl
+  become: yes
+- name: Copy additional Nomad configuration files
+  copy:
+    src: "{{ item }}"
+    dest: "/opt/nomad/config//{{ item | basename }}"
+    owner: "{{ nomad_user }}"
+  with_items: "{{ nomad_additional_config }}"
   become: yes
 - name: Install Configuration script
   copy:


### PR DESCRIPTION
Useful for users to define client's `meta` or `class`.