### PR TITLE
Do not restrict server types

### DIFF
--- a/modules/core/packer/roles/install-ssh-script/files/configure.sh
+++ b/modules/core/packer/roles/install-ssh-script/files/configure.sh
@@ -19,7 +19,7 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --type\t\tThe type of instance being configured. Required. Can be 'consul', 'vault', 'nomad_client' or 'nomad_server'."
+  echo -e "  --type\t\tThe type of instance being configured. Required. Keys must exist in Consul for the server type."
   echo -e "  --vault-service\t\tName of Vault service to query in Consul. Optional. Defaults to 'vault'."
   echo -e "  --vault-port\t\tPort of Vault service. Optional. Defaults to '8200'."
   echo -e "  --consul-prefix\t\tPath prefix in Consul KV store to query for integration status. Optional. Defaults to terraform/"
@@ -172,8 +172,8 @@ function main {
     shift
   done
 
-  if [[ "${type}" != "vault" && "${type}" != "consul" && "${type}" != "nomad_server" && "${type}" != "nomad_client" ]]; then
-    log_error "Invalid type set."
+  if [[ -z "${type}" ]]; then
+    log_error "You must specify the --type"
     exit 1
   fi
 

--- a/modules/telegraf/main.tf
+++ b/modules/telegraf/main.tf
@@ -1,9 +1,48 @@
-resource "consul_key_prefix" "core_integration" {
-  count       = "${var.core_integration ? 1 : 0}"
-  path_prefix = "${var.consul_key_prefix}telegraf/"
+resource "consul_keys" "core_integration" {
+  count = "${var.core_integration ? 1 : 0}"
 
-  subkeys {
-    "enabled" = "yes"
-    "README"  = "This is used for integration with the `core` module. See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf"
+  key {
+    path = "${var.consul_key_prefix}telegraf/README"
+
+    value = <<EOF
+This is used for integration with the `core` module.
+See https://github.com/GovTechSG/terraform-modules/tree/master/modules/telegraf
+EOF
+  }
+}
+
+resource "consul_keys" "consul" {
+  count = "${var.core_integration && var.consul_enabled ? 1 : 0}"
+
+  key {
+    path  = "${var.consul_key_prefix}telegraf/consul/enabled"
+    value = "true"
+  }
+}
+
+resource "consul_keys" "nomad_server" {
+  count = "${var.core_integration && var.nomad_server_enabled ? 1 : 0}"
+
+  key {
+    path  = "${var.consul_key_prefix}telegraf/nomad_server/enabled"
+    value = "true"
+  }
+}
+
+resource "consul_keys" "nomad_client" {
+  count = "${var.core_integration && var.nomad_client_enabled ? 1 : 0}"
+
+  key {
+    path  = "${var.consul_key_prefix}telegraf/nomad_client/enabled"
+    value = "true"
+  }
+}
+
+resource "consul_keys" "vault" {
+  count = "${var.core_integration && var.vault_enabled ? 1 : 0}"
+
+  key {
+    path  = "${var.consul_key_prefix}telegraf/vault/enabled"
+    value = "true"
   }
 }

--- a/modules/telegraf/variables.tf
+++ b/modules/telegraf/variables.tf
@@ -1,3 +1,23 @@
+variable "consul_enabled" {
+  description = "Enable Telegraf for Consul servers"
+  default     = true
+}
+
+variable "nomad_server_enabled" {
+  description = "Enable Telegraf for Nomad servers"
+  default     = true
+}
+
+variable "nomad_client_enabled" {
+  description = "Enable Telegraf for Nomad Clients"
+  default     = true
+}
+
+variable "vault_enabled" {
+  description = "Enable Telegraf for Vault servers"
+  default     = true
+}
+
 # --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is useful to define additional "server types" like a different class of Nomad Clients.

Also enable selective telegraf enabling on specific type of servers.