### PR TITLE
Fix Traefik accessing Consul via instance IP

### DIFF
--- a/modules/traefik/jobs/traefik.nomad
+++ b/modules/traefik/jobs/traefik.nomad
@@ -28,7 +28,7 @@ job "traefik" {
         args = [
           "--consul",
           "--consul.watch",
-          "--consul.endpoint=$${attr.unique.network.ip-address}:${consul_port}",
+          "--consul.endpoint=169.254.1.1:${consul_port}",
           "--consul.prefix=${traefik_consul_prefix}",
         ]
       }


### PR DESCRIPTION
- Use dummy address instead

Using instance IP did not work after #87 