### PR TITLE
Revert "Reduce the frequency in which ~/.vault-token is rendered"

### DIFF
--- a/modules/core/packer/roles/install-consul-template/files/run-consul-template.sh
+++ b/modules/core/packer/roles/install-consul-template/files/run-consul-template.sh
@@ -307,12 +307,6 @@ template {
   create_dest_dirs = true
   error_on_missing_key = true
   perms = 0600
-
-  # Vault Tokens should not change often. We can set this to something pretty long.
-  # If somehow you need to update the token, send a SIGHUP to consul-template.
-  wait {
-    min = "86400s"
-  }
 }
 EOF
 )


### PR DESCRIPTION
This reverts commit 6746885f900a26a9b886224fdc69cf3fe6622244.

`wait` also affects the initial rendering. 