### PR TITLE
Reorder User Data

### DIFF
--- a/modules/core/user_data/user-data-consul-server.sh
+++ b/modules/core/user_data/user-data-consul-server.sh
@@ -25,7 +25,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --syslog-enable \
     --consul-prefix "${consul_prefix}"
 
-/opt/run-telegraf \
+/opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"
 
@@ -33,6 +33,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"
 
-/opt/vault-ssh \
+/opt/run-telegraf \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"

--- a/modules/core/user_data/user-data-nomad-client.sh
+++ b/modules/core/user_data/user-data-nomad-client.sh
@@ -31,7 +31,9 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --syslog-enable \
     --consul-prefix "${consul_prefix}"
 
-/opt/run-telegraf \
+/opt/nomad/bin/run-nomad --client
+
+/opt/vault-ssh \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"
 
@@ -39,8 +41,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"
 
-/opt/nomad/bin/run-nomad --client
-
-/opt/vault-ssh \
+/opt/run-telegraf \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"

--- a/modules/core/user_data/user-data-nomad-server.sh
+++ b/modules/core/user_data/user-data-nomad-server.sh
@@ -26,14 +26,6 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
     --syslog-enable \
     --consul-prefix "${consul_prefix}"
 
-/opt/run-telegraf \
-    --consul-prefix "${consul_prefix}" \
-    --type "$service_type"
-
-/opt/run-td-agent \
-    --consul-prefix "${consul_prefix}" \
-    --type "$service_type"
-
 # Additional Configuration
 /opt/nomad/bin/configure \
     --server \
@@ -42,5 +34,13 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/nomad/bin/run-nomad --server --num-servers "${num_servers}"
 
 /opt/vault-ssh \
+    --consul-prefix "${consul_prefix}" \
+    --type "$service_type"
+
+/opt/run-td-agent \
+    --consul-prefix "${consul_prefix}" \
+    --type "$service_type"
+
+/opt/run-telegraf \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -38,14 +38,6 @@ AWS_DEFAULT_REGION="${aws_region}" \
     --syslog-enable \
     --consul-prefix "${consul_prefix}"
 
-/opt/run-telegraf \
-    --consul-prefix "${consul_prefix}" \
-    --type "$service_type"
-
-/opt/run-td-agent \
-    --consul-prefix "${consul_prefix}" \
-    --type "$service_type"
-
 # The Packer template puts the TLS certs in these file paths
 readonly VAULT_TLS_CERT_FILE="${cert_file}"
 readonly VAULT_TLS_KEY_FILE="${cert_key}"
@@ -65,5 +57,13 @@ else
 fi
 
 /opt/vault-ssh \
+    --consul-prefix "${consul_prefix}" \
+    --type "$service_type"
+
+/opt/run-td-agent \
+    --consul-prefix "${consul_prefix}" \
+    --type "$service_type"
+
+/opt/run-telegraf \
     --consul-prefix "${consul_prefix}" \
     --type "$service_type"


### PR DESCRIPTION
Currently, Fluentd and Prometheus/whatever time series DB can
potentially be run on Nomad. If the Nomad cluster is unhealthy
or the jobs are not running properly, new nodes will never be
able to bootstrap properly. We rearrange the order of launching
so that these nodes can still bootstrap their respective services.

On the downside, this means that we might not even know that the nodes
are not sending their logs.

Perhaps #44 will help?