### PR TITLE
Allow Docker privileged config to be set for Nomad Client

### DIFF
--- a/modules/nomad-clients/main.tf
+++ b/modules/nomad-clients/main.tf
@@ -76,6 +76,7 @@ data "template_file" "user_data_nomad_client" {
     client_node_class = "${var.client_node_class}"
     cluster_tag_key   = "${var.cluster_tag_key}"
     cluster_tag_value = "${var.consul_cluster_name}"
+    docker_privileged = "${var.docker_privileged ? "--docker-privileged" : ""}"
     consul_prefix     = "${var.integration_consul_prefix}"
     service_type      = "${coalesce(var.integration_service_type, var.cluster_name)}"
   }

--- a/modules/nomad-clients/user_data.sh
+++ b/modules/nomad-clients/user_data.sh
@@ -37,6 +37,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/nomad/bin/configure \
     --client \
     --client-node-class "${client_node_class}" \
+    "${docker_privileged}" \
     --consul-prefix "${consul_prefix}"
 
 /opt/nomad/bin/run-nomad --client

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -100,6 +100,11 @@ variable "client_node_class" {
   default     = "nomad-client"
 }
 
+variable "docker_privileged" {
+  description = "Flag to enable privileged mode for Docker agent on Nomad client"
+  default     = false
+}
+
 variable "cluster_tag_key" {
   description = "The tag the Consul EC2 Instances will look for to automatically discover each other and form a cluster."
   default     = "consul-servers"

--- a/roles/nomad/files/configure.sh
+++ b/roles/nomad/files/configure.sh
@@ -22,6 +22,7 @@ function print_usage {
   echo -e "  --server\t\tIf set, configure in server mode. Optional. Exactly one of --server or --client must be set."
   echo -e "  --client\t\tIf set, configure in client mode. Optional. Exactly one of --server or --client must be set."
   echo -e "  --client-node-class\t\tClient node class name. Must be set if --client is set."
+  echo -e "  --docker-privileged\t\Enable privileged mode for Docker agent. Only applicable if --client is set."
   echo -e "  --config-dir\t\tThe path to write the config files to. Optional. Default is the absolute path of '../config', relative to this script."
   echo -e "  --vault-address\t\tAddress of Vault server. Optional. Defaults to \"https://vault.service.consul:8200\""
   echo -e "  --consul-prefix\t\tPath prefix in Consul KV store to query for integration status. Optional. Defaults to terraform/"
@@ -166,6 +167,30 @@ EOF
   fi
 }
 
+function generate_client_docker_config {
+  local readonly client="${1}"
+  local readonly config_dir="${2}"
+  local readonly docker_privileged="${3}"
+  local readonly user="${4}"
+
+  if [[ "$client" == "true" ]]; then
+    log_info "Generating client Docker configuration for Nomad client"
+
+    local node_class_config=$(cat <<EOF
+client {
+  options {
+  }
+}
+EOF
+)
+    log_info "Writing Docker configuration to ${config_dir}/docker_privileged.hcl"
+    echo "${node_class_config}" > "${config_dir}/docker_privileged.hcl"
+    chown "${user}:${user}" "${config_dir}/docker_privileged.hcl"
+  else
+    log_info "Skipping client Docker configuration for Nomad server"
+  fi
+}
+
 function generate_vault_config {
   local readonly server="${1}"
   local readonly config_dir="${2}"
@@ -236,11 +261,13 @@ function generate_docker_config {
   local readonly user="${3}"
   local readonly consul_template_config="${4}"
   local readonly docker_auth_path="${5}"
+  local readonly docker_privileged="${6}"
 
   local docker_config=$(cat <<EOF
 client {
   options {
     "docker.auth.config" = "${docker_auth_path}"
+    "docker.privileged.enabled" = "${docker_privileged}"
   }
 }
 EOF
@@ -373,6 +400,7 @@ function main {
   local user=""
   local consul_template_config="/opt/consul-template/config"
   local docker_auth=""
+  local docker_privileged="false"
   local statsd_addr="127.0.0.1:8125"
   local telegraf_conf="/etc/telegraf/telegraf.d"
   local all_args=()
@@ -420,6 +448,9 @@ function main {
         assert_not_empty "$key" "$2"
         docker_auth="$2"
         shift
+        ;;
+      --docker-privileged)
+        docker_privileged="true"
         ;;
       --statsd-addr)
         assert_not_empty "$key" "$2"
@@ -499,7 +530,7 @@ function main {
   if [[ "${docker_auth_enabled}" != "yes" || "$server" == "true" ]]; then
     log_info "Docker authentication is not enabled or this is a Nomad server."
   else
-    generate_docker_config "${consul_prefix}" "${config_dir}" "${user}" "${consul_template_config}" "${docker_auth}"
+    generate_docker_config "${consul_prefix}" "${config_dir}" "${user}" "${consul_template_config}" "${docker_auth}" "${docker_privileged}"
     supervisorctl signal SIGHUP consul-template
   fi
 

--- a/roles/nomad/files/configure.sh
+++ b/roles/nomad/files/configure.sh
@@ -167,30 +167,6 @@ EOF
   fi
 }
 
-function generate_client_docker_config {
-  local readonly client="${1}"
-  local readonly config_dir="${2}"
-  local readonly docker_privileged="${3}"
-  local readonly user="${4}"
-
-  if [[ "$client" == "true" ]]; then
-    log_info "Generating client Docker configuration for Nomad client"
-
-    local node_class_config=$(cat <<EOF
-client {
-  options {
-  }
-}
-EOF
-)
-    log_info "Writing Docker configuration to ${config_dir}/docker_privileged.hcl"
-    echo "${node_class_config}" > "${config_dir}/docker_privileged.hcl"
-    chown "${user}:${user}" "${config_dir}/docker_privileged.hcl"
-  else
-    log_info "Skipping client Docker configuration for Nomad server"
-  fi
-}
-
 function generate_vault_config {
   local readonly server="${1}"
   local readonly config_dir="${2}"


### PR DESCRIPTION
Useful for certain services like Portworx, which requires privileged mode, like in this example: https://github.com/portworx/px-dev/blob/master/quick-start/docker-compose.yml