### PR TITLE
Add Portworx as possible Ansible installation module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "roles/ansible-ca-store"]
 	path = roles/ansible-ca-store
 	url = https://github.com/lawliet89/ansible-ca-store.git
-[submodule "roles/ansible-portworx-defaults"]
-	path = roles/ansible-portworx-defaults
-	url = https://github.com/portworx/ansible-portworx-defaults.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "roles/ansible-ca-store"]
 	path = roles/ansible-ca-store
 	url = https://github.com/lawliet89/ansible-ca-store.git
+[submodule "roles/ansible-portworx-defaults"]
+	path = roles/ansible-portworx-defaults
+	url = https://github.com/portworx/ansible-portworx-defaults.git

--- a/modules/portworx/.gitignore
+++ b/modules/portworx/.gitignore
@@ -1,0 +1,1 @@
+inventory

--- a/modules/portworx/packer/README.md
+++ b/modules/portworx/packer/README.md
@@ -1,0 +1,101 @@
+# Portworx AMI
+
+AMI with Portworx (`px-dev`) and Consul binaries installed. DNSmasq is also configured to use the
+local Consul agent as its DNS server.
+
+This is based on this
+[example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami).
+
+## Pre-requisite
+
+In addition to Ansible and Packer, you will need to install the following on your machine:
+
+- [`python_consul`](https://github.com/cablehead/python-consul)
+
+### Certificate Authority
+
+As part of the pre-requisites, you should already have generated certificates for a CA and,
+a certificate for Consul. You should install the certificate for Consul by pointing Packer to the
+path of the Certificate and CA.
+
+## Configuration Options
+
+See [this page](https://www.packer.io/docs/templates/user-variables.html) for more information.
+
+- `ami_base_name`: Base name for the AMI image. The timestamp will be appended
+- `aws_region`: AWS Region
+- `subnet_id`: ID of subnet to run the builder instance in
+- `temporary_security_group_source_cidr`: Temporary CIDR to allow SSH access from
+- `associate_public_ip_address`: Associate to `true` if the machine provisioned is to be connected
+  via the internet
+- `ssh_interface`: One of `public_ip`, `private_ip`, `public_dns` or `private_dns`. If set, either
+  the public IP address, private IP address, public DNS name or private DNS name will used as the
+  host for SSH. The default behaviour if inside a VPC is to use the public IP address if available,
+  otherwise the private IP address will be used. If not in a VPC the public DNS name will be used.
+- `consul_module_version`: Version of the
+  [Terraform Consul](https://github.com/hashicorp/terraform-aws-consul) repository to use
+- `consul_version`: Version of Consul to install
+- `td_agent_config_file`: Path to `td-agent` config file to template copy from. Install `td-agent`
+  if path is non-empty.
+- `td_agent_config_vars_file`: Path to variables file to include for value interpolation for
+  `td-agent` config file. Only included if the value is not empty. `include_vars` includes the
+  variables into `config_vars` variable, i.e. if `xxx` value is defined in the variables file, you
+  will need to do `{{ config_vars.xxx }}` to get the interpolation working.
+- `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
+  empty to not install anything.
+
+### Post Bootstrap Configuration
+
+After the initial bootstrap, if you have applied one of the following post bootstrap modules,
+you should set the following options to install whatever pre-requisite is required in the AMI:
+
+- Vault PKI
+
+The following options are common to all of the integrations:
+
+- `consul_host`: The host for which Consul is accessible. Defaults to empty. If set to empty, all post bootstrap integration will be disabled.
+- `consul_port`: Port where Consul is accessible. Defaults to 443
+- `consul_scheme`: Scheme to access Consul. Defaults to "https"
+- `consul_token`: ACL token to access Consul
+- `consul_integration_prefix`: Prefix to look for Consul integration values. Do not change this unless you have also modified the values in the appropriate modules. Defaults to "terraform/"
+
+## Building Image
+
+If you have a `vars.json` variables file containing changes to the above variables, you may run:
+
+```bash
+packer build \
+    -var-file=vars.json \
+    packer.json
+```
+
+Otherwise if you wish to use the default variable values, simply run:
+
+```bash
+packer build packer.json
+```
+
+If you have enabled the post-bootstrap integration, you can use `terraform output` to get the URL
+of your Consul servers. In this way, you can use the same command for pre and post bootstrap builds
+of your AMI.
+
+```bash
+packer build \
+    -var-file=vars.json \
+    -var consul_host="$(terraform output consul_api_address || echo -n '')" \
+    packer.json
+```
+
+## Components Installed
+
+This Packer image will the following:
+
+- Consul: `/opt/consul`
+- `td-agent`: As a Debian package
+- `telegraf` As a Debian package
+- [`consul-template`](https://github.com/hashicorp/consul-template): `/opt/consul-template`
+
+You can use `consul-template` to template files using data from Consul and Vault. Simply define
+the template using a new configuration file (in HCL, with the `template` stanza) and write the
+configuration file to `/opt/consul-template/config`.  You can send the `SIGHUP` signal using
+`supervisorctl signal SIGHUP consul-template` to ask `consul-template` to reload its configuration.

--- a/modules/portworx/packer/README.md
+++ b/modules/portworx/packer/README.md
@@ -1,10 +1,7 @@
 # Portworx AMI
 
-AMI with Portworx (`px-dev`) and Consul binaries installed. DNSmasq is also configured to use the
-local Consul agent as its DNS server.
-
-This is based on this
-[example](https://github.com/hashicorp/terraform-aws-nomad/tree/master/examples/nomad-consul-ami).
+AMI with Portworx and Consul binaries installed. DNSmasq is also configured to use the local Consul
+agent as its DNS server.
 
 ## Pre-requisite
 
@@ -43,6 +40,10 @@ See [this page](https://www.packer.io/docs/templates/user-variables.html) for mo
   will need to do `{{ config_vars.xxx }}` to get the interpolation working.
 - `ca_certificate`: Path to the CA certificate you have generated to install on the machine. Set to
   empty to not install anything.
+- `px_image`: Docker image to install Portworx. Defaults to `portworx/px-dev`.
+  `portworx/px-enterprise` can be used, but would require either free trial or paid license.
+- `px_args`: Arguments to pass to Portworx during run configuration. Check
+  <https://docs.portworx.com/runc/options.html> for more details.
 
 ### Post Bootstrap Configuration
 
@@ -90,6 +91,7 @@ packer build \
 
 This Packer image will the following:
 
+- Portworx
 - Consul: `/opt/consul`
 - `td-agent`: As a Debian package
 - `telegraf` As a Debian package

--- a/modules/portworx/packer/packer.json
+++ b/modules/portworx/packer/packer.json
@@ -23,7 +23,7 @@
         "px_data_if": "-d eth0",
         "px_mgmt_if": "-m eth0",
         "px_device_args": "-s /dev/xvdz",
-        "px_cluster_id": "-c px-ingest"
+        "px_cluster_id": "-c my-portworx-cluster"
     },
     "builders": [
         {

--- a/modules/portworx/packer/packer.json
+++ b/modules/portworx/packer/packer.json
@@ -22,8 +22,8 @@
         "px_kvbd": "-k consul:http://127.0.0.1:8500",
         "px_data_if": "-d eth0",
         "px_mgmt_if": "-m eth0",
-        "px_device_args": "-m /dev/xvdz",
-        "px_cluster_id": "px-cluster"
+        "px_device_args": "-s /dev/xvdz",
+        "px_cluster_id": "px-ingest"
     },
     "builders": [
         {

--- a/modules/portworx/packer/packer.json
+++ b/modules/portworx/packer/packer.json
@@ -92,7 +92,7 @@
                 "-e",
                 "consul_host={{user `consul_host`}} consul_port={{user `consul_port`}} consul_scheme={{user `consul_scheme`}} consul_token={{user `consul_token`}} consul_integration_prefix={{user `consul_integration_prefix`}}",
                 "-e",
-                "px_kvbd={{user `px_kvbd`}} px_data_if={{user `px_data_if`}} px_mgmt_if={{user `px_mgmt_if`}} px_device_args={{user `px_device_args`}} px_cluster_id={{user `px_cluster_id`}}",
+                "px_kvbd=\"{{user `px_kvbd`}}\" px_data_if=\"{{user `px_data_if`}}\" px_mgmt_if=\"{{user `px_mgmt_if`}}\" px_device_args=\"{{user `px_device_args`}}\" px_cluster_id=\"{{user `px_cluster_id`}}\"",
                 "-e",
                 "ansible_python_interpreter=/usr/bin/python3"
             ]

--- a/modules/portworx/packer/packer.json
+++ b/modules/portworx/packer/packer.json
@@ -23,7 +23,7 @@
         "px_data_if": "-d eth0",
         "px_mgmt_if": "-m eth0",
         "px_device_args": "-s /dev/xvdz",
-        "px_cluster_id": "px-ingest"
+        "px_cluster_id": "-c px-ingest"
     },
     "builders": [
         {

--- a/modules/portworx/packer/packer.json
+++ b/modules/portworx/packer/packer.json
@@ -1,0 +1,101 @@
+{
+    "min_packer_version": "1.1.2",
+    "variables": {
+        "ami_base_name": "portworx",
+        "aws_region": "ap-southeast-1",
+        "subnet_id": "",
+        "temporary_security_group_source_cidr": "0.0.0.0/0",
+        "associate_public_ip_address": "true",
+        "ssh_interface": "",
+        "consul_module_repo": "https://github.com/hashicorp/terraform-aws-consul.git",
+        "consul_module_version": "v0.3.5",
+        "consul_version": "1.2.2",
+        "consul_enable_syslog": "true",
+        "td_agent_config_file": "",
+        "td_agent_config_vars_file": "",
+        "ca_certificate": "",
+        "consul_host": "",
+        "consul_port": "443",
+        "consul_scheme": "https",
+        "consul_token": "",
+        "consul_integration_prefix": "terraform/",
+        "px_kvbd": "-k consul:http://127.0.0.1:8500",
+        "px_data_if": "-d eth0",
+        "px_mgmt_if": "-m eth0",
+        "px_device_args": "-m /dev/xvdz",
+        "px_cluster_id": "px-cluster"
+    },
+    "builders": [
+        {
+            "name": "ubuntu-1604-portworx-ami",
+            "ami_name": "{{ user `ami_base_name` }}-{{isotime | clean_ami_name}}",
+            "ami_description": "An Ubuntu 16.04 AMI that has Consul installed.",
+            "instance_type": "t2.micro",
+            "region": "{{user `aws_region`}}",
+            "type": "amazon-ebs",
+            "subnet_id": "{{user `subnet_id`}}",
+            "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
+            "ssh_interface": "{{user `ssh_interface`}}",
+            "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+            "source_ami_filter": {
+                "filters": {
+                    "virtualization-type": "hvm",
+                    "architecture": "x86_64",
+                    "name": "*ubuntu-xenial-16.04-amd64-server-*",
+                    "block-device-mapping.volume-type": "gp2",
+                    "root-device-type": "ebs"
+                },
+                "owners": [
+                    "099720109477"
+                ],
+                "most_recent": true
+            },
+            "ssh_username": "ubuntu",
+            "run_tags":{
+                "Name": "{{user `ami_base_name` }}-{{isotime | clean_ami_name}}",
+                "Base Name": "{{user `ami_base_name` }}",
+                "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+                "Packer": "yes",
+                "Consul Version": "{{user `consul_version` }}"
+            },
+            "tags": {
+                "Name": "{{user `ami_base_name` }}-{{isotime | clean_ami_name}}",
+                "Base Name": "{{user `ami_base_name` }}",
+                "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+                "Packer": "yes",
+                "Consul Version": "{{user `consul_version` }}"
+            },
+            "snapshot_tags": {
+                "Name": "{{user `ami_base_name` }}-{{isotime | clean_ami_name}}",
+                "Base Name": "{{user `ami_base_name` }}",
+                "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+                "Packer": "yes",
+                "Consul Version": "{{user `consul_version` }}"
+            }
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "ansible",
+            "pause_before": "10s",
+            "playbook_file": "{{ template_dir }}/site.yml",
+            "user": "ubuntu",
+            "extra_arguments": [
+                "-e",
+                "consul_module_version={{user `consul_module_version`}} consul_version={{user `consul_version`}} consul_module_repo={{user `consul_module_repo`}}",
+                "-e",
+                "{ \"consul_enable_syslog\": {{user `consul_enable_syslog`}} }",
+                "-e",
+                "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+                "-e",
+                "ca_certificate={{user `ca_certificate`}}",
+                "-e",
+                "consul_host={{user `consul_host`}} consul_port={{user `consul_port`}} consul_scheme={{user `consul_scheme`}} consul_token={{user `consul_token`}} consul_integration_prefix={{user `consul_integration_prefix`}}",
+                "-e",
+                "px_kvbd={{user `px_kvbd`}} px_data_if={{user `px_data_if`}} px_mgmt_if={{user `px_mgmt_if`}} px_device_args={{user `px_device_args`}} px_cluster_id={{user `px_cluster_id`}}",
+                "-e",
+                "ansible_python_interpreter=/usr/bin/python3"
+            ]
+        }
+    ]
+}

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -19,7 +19,7 @@
     px_data_if: "-d eth0"
     px_mgmt_if: "-m eth0"
     px_device_args: "-s /dev/xvdz"
-    px_cluster_id: "px-ingest"
+    px_cluster_id: "-c px-ingest"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -19,7 +19,7 @@
     px_data_if: "-d eth0"
     px_mgmt_if: "-m eth0"
     px_device_args: "-s /dev/xvdz"
-    px_cluster_id: "-c px-ingest"
+    px_cluster_id: "-c my-portworx-cluster"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -15,11 +15,7 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
-    px_kvbd: "-k consul:http://127.0.0.1:8500"
-    px_data_if: "-d eth0"
-    px_mgmt_if: "-m eth0"
-    px_device_args: "-s /dev/xvdz"
-    px_cluster_id: "-c my-portworx-cluster"
+    px_args: "-k consul:http://127.0.0.1:8500 -c my-portworx-cluster -d eth0 -m eth0 -z"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -47,12 +43,6 @@
   - name: Install Portworx
     include_role:
       name: "{{ playbook_dir }}/../../../roles/ansible-portworx-runc"
-    vars:
-      kvdb: "{{ px_kvbd }}"
-      data_if: "{{ px_data_if }}"
-      mgmt_if: "{{ px_mgmt_if }}"
-      device_args: "{{ px_device_args }}"
-      cluster_id: "{{ px_cluster_id }}"
   - name: Install td-agent
     include_role:
       name: "{{ playbook_dir }}/../../../roles/td-agent"

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -47,6 +47,10 @@
   - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../../../roles/telegraf"
+  - name: Install pip3
+    apt:
+      name: python3-pip
+    become: yes
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../../../roles/consul"

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -28,7 +28,7 @@
     become: yes
   - name: Install CA Certificate
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+      name: "{{ playbook_dir }}/../../../roles/ansible-ca-store"
     vars:
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
@@ -36,29 +36,29 @@
     when: ca_certificate != ""
   - name: Install Vault PKI CA Certificate
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/vault-pki"
+      name: "{{ playbook_dir }}/../../../roles/vault-pki"
   - name: Install td-agent
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/td-agent"
+      name: "{{ playbook_dir }}/../../../roles/td-agent"
     vars:
       config_file: "{{ td_agent_config_file }}"
       config_vars_file: "{{ td_agent_config_vars_file }}"
       config_dest_file: "{{ td_agent_config_dest_file }}"
   - name: Install Telegraf
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/telegraf"
+      name: "{{ playbook_dir }}/../../../roles/telegraf"
   - name: Install Consul
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/consul"
+      name: "{{ playbook_dir }}/../../../roles/consul"
   - name: Install Consul-Template
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/install-consul-template"
+      name: "{{ playbook_dir }}/../../../roles/install-consul-template"
   - name: Install Vault SSH Configuration Script
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/install-ssh-script"
+      name: "{{ playbook_dir }}/../../../roles/install-ssh-script"
   - name: Install Docker and Docker Compose
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"      
+      name: "{{ playbook_dir }}/../../../roles/ansible-docker-ubuntu"      
   - name: Install Portworx
     include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-portworx-defaults"
+      name: "{{ playbook_dir }}/../../../roles/ansible-portworx-defaults"

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -66,3 +66,9 @@
   - name: Install Portworx
     include_role:
       name: "{{ playbook_dir }}/../../../roles/ansible-portworx-defaults"
+    vars:
+      kvdb: "{{ px_kvbd }}"
+      data_if: "{{ px_data_if }}"
+      mgmt_if: "{{ px_mgmt_if }}"
+      device_args: "{{ px_device_args }}"
+      cluster_id: "{{ px_cluster_id }}"

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -15,7 +15,6 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
-    px_args: "-k consul:http://127.0.0.1:8500 -c my-portworx-cluster -d eth0 -m eth0 -z"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -1,0 +1,64 @@
+---
+- name: Provision Consul AMI
+  hosts: all
+  vars:
+    consul_module_repo: "https://github.com/hashicorp/terraform-aws-consul.git"
+    consul_module_version: "v0.3.5"
+    consul_version: "1.2.2"
+    consul_enable_syslog: true
+    td_agent_config_file: ""
+    td_agent_config_vars_file: ""
+    td_agent_config_dest_file: "/etc/td-agent/td-agent.conf"
+    ca_certificate: ""
+    consul_host: ""
+    consul_port: 443
+    consul_scheme: https
+    consul_token: ""
+    consul_integration_prefix: "terraform/"
+    px_kvbd: "-k consul:http://127.0.0.1:8500"
+    px_data_if: "-d eth0"
+    px_mgmt_if: "-m eth0"
+    px_device_args: "-m /dev/xvdz"
+    px_cluster_id: "px-cluster"
+  tasks:
+  - name: Upgrade all packages to the latest version
+    apt:
+      upgrade: yes
+      update_cache: yes
+    become: yes
+  - name: Install CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+    vars:
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate != ""
+  - name: Install Vault PKI CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/vault-pki"
+  - name: Install td-agent
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/td-agent"
+    vars:
+      config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
+      config_dest_file: "{{ td_agent_config_dest_file }}"
+  - name: Install Telegraf
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/telegraf"
+  - name: Install Consul
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/consul"
+  - name: Install Consul-Template
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/install-consul-template"
+  - name: Install Vault SSH Configuration Script
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/install-ssh-script"
+  - name: Install Docker and Docker Compose
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"      
+  - name: Install Portworx
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/ansible-portworx-defaults"

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -15,6 +15,8 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
+    px_image: "portworx/px-dev:1.4.2.2"
+    px_args: "-k consul:http://127.0.0.1:8500 -c my-portworx-cluster -d eth0 -m eth0 -z"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/modules/portworx/packer/site.yml
+++ b/modules/portworx/packer/site.yml
@@ -18,8 +18,8 @@
     px_kvbd: "-k consul:http://127.0.0.1:8500"
     px_data_if: "-d eth0"
     px_mgmt_if: "-m eth0"
-    px_device_args: "-m /dev/xvdz"
-    px_cluster_id: "px-cluster"
+    px_device_args: "-s /dev/xvdz"
+    px_cluster_id: "px-ingest"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -37,6 +37,22 @@
   - name: Install Vault PKI CA Certificate
     include_role:
       name: "{{ playbook_dir }}/../../../roles/vault-pki"
+  - name: Install pip3
+    apt:
+      name: python3-pip
+    become: yes
+  - name: Install Docker and Docker Compose
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/ansible-docker-ubuntu"
+  - name: Install Portworx
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/ansible-portworx-runc"
+    vars:
+      kvdb: "{{ px_kvbd }}"
+      data_if: "{{ px_data_if }}"
+      mgmt_if: "{{ px_mgmt_if }}"
+      device_args: "{{ px_device_args }}"
+      cluster_id: "{{ px_cluster_id }}"
   - name: Install td-agent
     include_role:
       name: "{{ playbook_dir }}/../../../roles/td-agent"
@@ -47,10 +63,6 @@
   - name: Install Telegraf
     include_role:
       name: "{{ playbook_dir }}/../../../roles/telegraf"
-  - name: Install pip3
-    apt:
-      name: python3-pip
-    become: yes
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../../../roles/consul"
@@ -60,15 +72,3 @@
   - name: Install Vault SSH Configuration Script
     include_role:
       name: "{{ playbook_dir }}/../../../roles/install-ssh-script"
-  - name: Install Docker and Docker Compose
-    include_role:
-      name: "{{ playbook_dir }}/../../../roles/ansible-docker-ubuntu"      
-  - name: Install Portworx
-    include_role:
-      name: "{{ playbook_dir }}/../../../roles/ansible-portworx-defaults"
-    vars:
-      kvdb: "{{ px_kvbd }}"
-      data_if: "{{ px_data_if }}"
-      mgmt_if: "{{ px_mgmt_if }}"
-      device_args: "{{ px_device_args }}"
-      cluster_id: "{{ px_cluster_id }}"

--- a/roles/ansible-portworx-runc/defaults/main.yml
+++ b/roles/ansible-portworx-runc/defaults/main.yml
@@ -3,11 +3,11 @@
 
 # portworx/px-enterprise also available
 px_image: portworx/px-dev:1.4.2.2
-kvdb: -k consul:http://127.0.0.1:8500
-cluster_id: -c my-portworx-cluster
-data_if: -d eth0
-mgmt_if: -m eth0
-device_args: -s /dev/xvdz
+kvdb: "-k consul:http://127.0.0.1:8500"
+cluster_id: "-c my-portworx-cluster"
+data_if: "-d eth0"
+mgmt_if: "-m eth0"
+device_args: "-s /dev/xvdz"
 storageless: ""
 force: ""
 journal_dev: ""

--- a/roles/ansible-portworx-runc/defaults/main.yml
+++ b/roles/ansible-portworx-runc/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # For full description of options, please see https://docs.portworx.com/runc/options.html
 
-# portworx/px-enterprise also available
+# portworx/px-dev supports up to 3 nodes in cluster only
+# portworx/px-enterprise supports up to 1000 nodes
+# Check https://portworx.com/products/features/ for comparison
 px_image: portworx/px-dev:1.4.2.2
 kvdb: "-k consul:http://127.0.0.1:8500"
 cluster_id: "-c my-portworx-cluster"

--- a/roles/ansible-portworx-runc/defaults/main.yml
+++ b/roles/ansible-portworx-runc/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# For full description of options, please see https://docs.portworx.com/runc/options.html
+
+# portworx/px-enterprise also available
+px_image: portworx/px-dev:1.4.2.2
+kvdb: consul:http://127.0.0.1:8500
+cluster_id: -c my-portworx-cluster
+data_if: -d eth0
+mgmt_if: -m eth0
+device_args: -s /dev/xvdz
+storageless: ""
+force: ""
+journal_dev: ""
+scheduler: ""
+pxenviron: ""

--- a/roles/ansible-portworx-runc/defaults/main.yml
+++ b/roles/ansible-portworx-runc/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # portworx/px-enterprise also available
 px_image: portworx/px-dev:1.4.2.2
-kvdb: consul:http://127.0.0.1:8500
+kvdb: -k consul:http://127.0.0.1:8500
 cluster_id: -c my-portworx-cluster
 data_if: -d eth0
 mgmt_if: -m eth0

--- a/roles/ansible-portworx-runc/defaults/main.yml
+++ b/roles/ansible-portworx-runc/defaults/main.yml
@@ -5,13 +5,4 @@
 # portworx/px-enterprise supports up to 1000 nodes
 # Check https://portworx.com/products/features/ for comparison
 px_image: portworx/px-dev:1.4.2.2
-kvdb: "-k consul:http://127.0.0.1:8500"
-cluster_id: "-c my-portworx-cluster"
-data_if: "-d eth0"
-mgmt_if: "-m eth0"
-device_args: "-s /dev/xvdz"
-storageless: ""
-force: ""
-journal_dev: ""
-scheduler: ""
-pxenviron: ""
+px_args: "-k consul:http://127.0.0.1:8500 -c my-portworx-cluster -d eth0 -m eth0 -z"

--- a/roles/ansible-portworx-runc/tasks/main.yml
+++ b/roles/ansible-portworx-runc/tasks/main.yml
@@ -1,0 +1,19 @@
+# sudo docker run --entrypoint /runc-entry-point.sh --rm -i --privileged=true -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx {{ px_image }}
+#
+# (runtime after Consul is up?)
+# sudo /opt/pwx/bin/px-runc install -k consul:http://127.0.0.1:8500 -c px-cluster -d eth0 -m eth0 -s /dev/xvdz
+#
+# sudo systemctl daemon-reload
+# sudo systemctl enable portworx
+# sudo systemctl start portworx
+---
+- name: Install Portworx ({{ px_image }})
+  docker_container:
+    name: portworx-install
+    image: "{{ px_image }}"
+    volumes:
+    - "/opt/pwx:/opt/pwx"
+    - "/etc/pwx:/etc/pwx"
+    auto_remove: yes
+    privileged: yes
+  become: yes

--- a/roles/ansible-portworx-runc/tasks/main.yml
+++ b/roles/ansible-portworx-runc/tasks/main.yml
@@ -3,15 +3,21 @@
   docker_container:
     name: portworx-install
     image: "{{ px_image }}"
+    detach: no
+    entrypoint: /runc-entry-point.sh
+    command: --upgrade
     volumes:
     - "/opt/pwx:/opt/pwx"
     - "/etc/pwx:/etc/pwx"
-    auto_remove: yes
+    state: started
+    cleanup: yes
     privileged: yes
   become: yes
-- command: "/opt/pwx/bin/px-runc install {{ kvdb }} {{ cluster_id }} {{ data_if }} {{ mgmt_if }} {{ device_args }} {{ storageless }} {{ force }} {{ journal_dev }} {{ scheduler }} {{ pxenviron }}"
+- name: Run Portworx install configuration
+  command: "/opt/pwx/bin/px-runc install {{ kvdb }} {{ cluster_id }} {{ data_if }} {{ mgmt_if }} {{ device_args }} {{ storageless }} {{ force }} {{ journal_dev }} {{ scheduler }} {{ pxenviron }}"
   become: yes
-- service:
+- name: Enable Portworx service to run on startup
+  service:
     name: portworx
     enabled: yes
     use: service

--- a/roles/ansible-portworx-runc/tasks/main.yml
+++ b/roles/ansible-portworx-runc/tasks/main.yml
@@ -12,7 +12,7 @@
 - command: "/opt/pwx/bin/px-runc install {{ kvdb }} {{ cluster_id }} {{ data_if }} {{ mgmt_if }} {{ device_args }} {{ storageless }} {{ force }} {{ journal_dev }} {{ scheduler }} {{ pxenviron }}"
   become: yes
 - service:
-  name: portworx
-  enabled: yes
-  use: service
+    name: portworx
+    enabled: yes
+    use: service
   become: yes

--- a/roles/ansible-portworx-runc/tasks/main.yml
+++ b/roles/ansible-portworx-runc/tasks/main.yml
@@ -1,11 +1,3 @@
-# sudo docker run --entrypoint /runc-entry-point.sh --rm -i --privileged=true -v /opt/pwx:/opt/pwx -v /etc/pwx:/etc/pwx {{ px_image }}
-#
-# (runtime after Consul is up?)
-# sudo /opt/pwx/bin/px-runc install -k consul:http://127.0.0.1:8500 -c px-cluster -d eth0 -m eth0 -s /dev/xvdz
-#
-# sudo systemctl daemon-reload
-# sudo systemctl enable portworx
-# sudo systemctl start portworx
 ---
 - name: Install Portworx ({{ px_image }})
   docker_container:
@@ -16,4 +8,11 @@
     - "/etc/pwx:/etc/pwx"
     auto_remove: yes
     privileged: yes
+  become: yes
+- command: "/opt/pwx/bin/px-runc install {{ kvdb }} {{ cluster_id }} {{ data_if }} {{ mgmt_if }} {{ device_args }} {{ storageless }} {{ force }} {{ journal_dev }} {{ scheduler }} {{ pxenviron }}"
+  become: yes
+- service:
+  name: portworx
+  enabled: yes
+  use: service
   become: yes

--- a/roles/ansible-portworx-runc/tasks/main.yml
+++ b/roles/ansible-portworx-runc/tasks/main.yml
@@ -14,7 +14,7 @@
     privileged: yes
   become: yes
 - name: Run Portworx install configuration
-  command: "/opt/pwx/bin/px-runc install {{ kvdb }} {{ cluster_id }} {{ data_if }} {{ mgmt_if }} {{ device_args }} {{ storageless }} {{ force }} {{ journal_dev }} {{ scheduler }} {{ pxenviron }}"
+  command: "/opt/pwx/bin/px-runc install {{ px_args }}"
   become: yes
 - name: Enable Portworx service to run on startup
   service:


### PR DESCRIPTION
Built AMI can be used in any ASG, and integrates with Consul.

The packer build is basically Consul packer + the new `ansible-portworx-runc` installation module.