### PR TITLE
Add new docker-volume-netshare role for nomad-clients

### DIFF
--- a/modules/core/consul.tf
+++ b/modules/core/consul.tf
@@ -4,6 +4,7 @@
 
 locals {
   consul_http_api_port = 8500
+  consul_user_data     = "${coalesce(var.consul_user_data, data.template_file.user_data_consul_server.rendered)}"
 }
 
 module "consul_servers" {
@@ -27,7 +28,7 @@ module "consul_servers" {
   cluster_tag_value = "${var.consul_cluster_name}"
 
   ami_id    = "${var.consul_ami_id}"
-  user_data = "${coalesce(var.consul_user_data, data.template_file.user_data_consul_server.rendered)}"
+  user_data = "${local.consul_user_data}"
 
   root_volume_type = "${var.consul_root_volume_type}"
   root_volume_size = "${var.consul_root_volume_size}"

--- a/modules/core/nomad_servers.tf
+++ b/modules/core/nomad_servers.tf
@@ -4,6 +4,7 @@
 
 locals {
   nomad_server_http_port = 4646
+  nomad_server_user_data = "${coalesce(var.nomad_servers_user_data, data.template_file.user_data_nomad_server.rendered)}"
 }
 
 module "nomad_servers" {
@@ -20,7 +21,7 @@ module "nomad_servers" {
   desired_capacity = "${var.nomad_servers_num}"
 
   ami_id    = "${var.nomad_servers_ami_id}"
-  user_data = "${coalesce(var.nomad_servers_user_data, data.template_file.user_data_nomad_server.rendered)}"
+  user_data = "${local.nomad_server_user_data}"
 
   root_volume_type = "${var.nomad_servers_root_volume_type}"
   root_volume_size = "${var.nomad_servers_root_volume_size}"

--- a/modules/core/outputs.tf
+++ b/modules/core/outputs.tf
@@ -180,9 +180,19 @@ output "consul_server_default_user_data" {
   value       = "${data.template_file.user_data_consul_server.rendered}"
 }
 
+output "consul_server_user_data" {
+  description = "Default launch configuration user data for Consul Server"
+  value       = "${local.consul_user_data}"
+}
+
 output "nomad_client_default_user_data" {
   description = "Default launch configuration user data for Nomad Client"
   value       = "${module.nomad_clients.default_user_data}"
+}
+
+output "nomad_client_user_data" {
+  description = "User data used by Nomad Client"
+  value       = "${module.nomad_clients.user_data}"
 }
 
 output "nomad_server_default_user_data" {
@@ -190,9 +200,19 @@ output "nomad_server_default_user_data" {
   value       = "${data.template_file.user_data_nomad_server.rendered}"
 }
 
+output "nomad_server_user_data" {
+  description = "User data used by Nomad Server"
+  value       = "${local.nomad_server_user_data}"
+}
+
 output "vault_cluster_default_user_data" {
   description = "Default launch configuration user data for Vault Cluster"
   value       = "${data.template_file.user_data_vault_cluster.rendered}"
+}
+
+output "vault_cluster_user_data" {
+  description = "User data used by Vault Cluster"
+  value       = "${local.vault_user_data}"
 }
 
 output "ssh_key_name" {

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -21,6 +21,7 @@
     consul_token: ""
     consul_integration_prefix: "terraform/"
     nomad_additional_config: []
+    netshare_version: 0.35
   tasks:
   - name: Upgrade all packages to the latest version
     apt:
@@ -52,6 +53,9 @@
     apt:
       name: python3-pip
     become: yes
+  - name: Install Docker Volume Netshare
+    include_role:
+      name: "{{ playbook_dir }}/../../../../roles/docker-volume-netshare"
   - name: Install Consul
     include_role:
       name: "{{ playbook_dir }}/../../../../roles/consul"

--- a/modules/core/vault.tf
+++ b/modules/core/vault.tf
@@ -3,7 +3,8 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
-  vault_api_port = 8200
+  vault_api_port  = 8200
+  vault_user_data = "${coalesce(var.vault_user_data, data.template_file.user_data_vault_cluster.rendered)}"
 }
 
 module "vault" {
@@ -14,7 +15,7 @@ module "vault" {
   instance_type = "${var.vault_instance_type}"
 
   ami_id    = "${var.vault_ami_id}"
-  user_data = "${coalesce(var.vault_user_data, data.template_file.user_data_vault_cluster.rendered)}"
+  user_data = "${local.vault_user_data}"
 
   root_volume_type = "${var.vault_root_volume_type}"
   root_volume_size = "${var.vault_root_volume_size}"

--- a/modules/nomad-clients/main.tf
+++ b/modules/nomad-clients/main.tf
@@ -1,6 +1,7 @@
 locals {
   allowed_inbound_cidr_blocks = "${concat(list(data.aws_vpc.selected.cidr_block), var.allowed_inbound_cidr_blocks)}"
   services_inbound_cidr       = "${concat(list(data.aws_vpc.selected.cidr_block), var.nomad_clients_services_inbound_cidr)}"
+  user_data                   = "${coalesce(var.user_data, data.template_file.user_data_nomad_client.rendered)}"
 }
 
 data "aws_vpc" "selected" {
@@ -24,7 +25,7 @@ module "nomad_clients" {
   desired_capacity = "${var.clients_desired}"
 
   ami_id    = "${var.ami_id}"
-  user_data = "${coalesce(var.user_data, data.template_file.user_data_nomad_client.rendered)}"
+  user_data = "${local.user_data}"
 
   root_volume_type = "${var.root_volume_type}"
   root_volume_size = "${var.root_volume_size}"

--- a/modules/nomad-clients/outputs.tf
+++ b/modules/nomad-clients/outputs.tf
@@ -38,6 +38,11 @@ output "default_user_data" {
   value       = "${data.template_file.user_data_nomad_client.rendered}"
 }
 
+output "user_data" {
+  description = "User data used for Nomad Clients"
+  value       = "${local.user_data}"
+}
+
 output "ssh_key_name" {
   description = "Name of SSH Key for SSH login authentication to Nomad Clients cluster"
   value       = "${var.ssh_key_name}"

--- a/modules/nomad-clients/user_data.sh
+++ b/modules/nomad-clients/user_data.sh
@@ -37,7 +37,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 /opt/nomad/bin/configure \
     --client \
     --client-node-class "${client_node_class}" \
-    "${docker_privileged}" \
+    ${docker_privileged} \
     --consul-prefix "${consul_prefix}"
 
 /opt/nomad/bin/run-nomad --client

--- a/roles/docker-volume-netshare/defaults/main.yml
+++ b/roles/docker-volume-netshare/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+netshare_version: 0.35

--- a/roles/docker-volume-netshare/files/docker-volume-netshare
+++ b/roles/docker-volume-netshare/files/docker-volume-netshare
@@ -1,0 +1,1 @@
+DKV_NETSHARE_OPTS="efs --nameserver=169.254.1.1"

--- a/roles/docker-volume-netshare/tasks/main.yml
+++ b/roles/docker-volume-netshare/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install dnsmasq and git via apt
+  apt:
+    name: nfs-common
+    state: latest
+  become: yes
+- name: Install Docker Volume Netshare deb
+  apt:
+    deb: "https://github.com/ContainX/docker-volume-netshare/releases/download/v{{ netshare_version }}/docker-volume-netshare_{{ netshare_version }}_amd64.deb"
+  become: yes
+- name: Enable Docker Volume Netshare service
+  service:
+    name: docker-volume-netshare
+    enabled: yes
+    use: service
+  become: yes
+- name: Update Netshare configuration
+  copy:
+    src: "{{ playbook_dir }}/files/docker-volume-netshare"
+    dest: "/etc/default/docker-volume-netshare"
+  become: yes

--- a/roles/docker-volume-netshare/tasks/main.yml
+++ b/roles/docker-volume-netshare/tasks/main.yml
@@ -16,6 +16,6 @@
   become: yes
 - name: Update Netshare configuration
   copy:
-    src: "{{ role_path }}/../files/docker-volume-netshare"
+    src: "{{ role_path }}/files/docker-volume-netshare"
     dest: "/etc/default/docker-volume-netshare"
   become: yes

--- a/roles/docker-volume-netshare/tasks/main.yml
+++ b/roles/docker-volume-netshare/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install dnsmasq and git via apt
+- name: Install NFS common dependency
   apt:
     name: nfs-common
     state: latest
@@ -16,6 +16,6 @@
   become: yes
 - name: Update Netshare configuration
   copy:
-    src: "{{ playbook_dir }}/files/docker-volume-netshare"
+    src: "{{ role_path }}/../files/docker-volume-netshare"
     dest: "/etc/default/docker-volume-netshare"
   become: yes


### PR DESCRIPTION
This allows Nomad clients to mount NFS, EFS, SMB based filesystem to any Docker containers via Docker volume drivers set-up: https://github.com/ContainX/docker-volume-netshare.