### PR TITLE
Couple of small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 - Update Packer Templates to use `t3` instances
 - Remove serf gossip rules from Core module (see [#153](https://github.com/GovTechSG/terraform-modules/pull/153))
+- Fix `vault-pki` Ansible role conditional check for Consul integration failing when the integration does not exist
+- Allow the `terraform` command to be replaced in Core's `vault-helper` script when something else like terragrunt is used

--- a/modules/core/vault-helper.sh
+++ b/modules/core/vault-helper.sh
@@ -14,6 +14,8 @@ readonly SCRIPT_NAME="$(basename "$0")"
 readonly MAX_RETRIES=30
 readonly SLEEP_BETWEEN_RETRIES_SEC=10
 
+TERRAFORM="${TERRAFORM:-terraform}"
+
 function log {
   local readonly level="$1"
   local readonly message="$2"
@@ -47,7 +49,7 @@ function assert_is_installed {
 
 function get_optional_terraform_output {
   local readonly output_name="$1"
-  terraform output -no-color "$output_name"
+  "${TERRAFORM}" output -no-color "$output_name"
 }
 
 function get_required_terraform_output {

--- a/roles/vault-pki/tasks/main.yml
+++ b/roles/vault-pki/tasks/main.yml
@@ -61,4 +61,4 @@
         certificate: "{{ download_temp.path }}"
         certificate_rename: "vault.crt"
       become: yes
-  when: consul_host != "" and integration_enabled and integration_enabled.data.Value == "yes"
+  when: consul_host != "" and integration_enabled and integration_enabled.data and integration_enabled.data.Value == "yes"


### PR DESCRIPTION
- Fix `vault-pki` Ansible role conditional check for Consul integration
failing when the integration does not exist
- Allow the `terraform` command to be replaced in Core's `vault-helper`
script when something else like terragrunt is used