### PR TITLE
Custom task `include_role_checked` for checking submodule Tasks

### DIFF
--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -24,7 +24,7 @@
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
-      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+      role: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes

--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -22,13 +22,12 @@
       update_cache: yes
     become: yes
   - name: Install CA Certificate
-    include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+    include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
+      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes
-    when: ca_certificate != ""
   - name: Install Vault PKI CA Certificate
     include_role:
       name: "{{ playbook_dir }}/../../../../roles/vault-pki"

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -32,7 +32,7 @@
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
-      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+      role: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes
@@ -72,7 +72,7 @@
   - name: Install Docker and Docker Compose
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
-      role_path: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"
+      role: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"
   - name: Install Vault SSH Configuration Script
     include_role:
       name: "{{ playbook_dir }}/../../../../roles/install-ssh-script"

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -30,9 +30,9 @@
       update_cache: yes
     become: yes
   - name: Install CA Certificate
-    include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+    include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
+      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes
@@ -70,8 +70,9 @@
     include_role:
       name: "{{ playbook_dir }}/../../../../roles/nomad"
   - name: Install Docker and Docker Compose
-    include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"
+    include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
+    vars:
+      role_path: "{{ playbook_dir }}/../../../../roles/ansible-docker-ubuntu"
   - name: Install Vault SSH Configuration Script
     include_role:
       name: "{{ playbook_dir }}/../../../../roles/install-ssh-script"

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -29,7 +29,7 @@
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
-      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+      role: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -27,9 +27,9 @@
       update_cache: yes
     become: yes
   - name: Install CA Certificate
-    include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+    include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
+      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -30,9 +30,9 @@
       update_cache: yes
     become: yes
   - name: Install CA Certificate
-    include_role:
-      name: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+    include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
+      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -32,7 +32,7 @@
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:
-      role_path: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
+      role: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
     become: yes

--- a/roles/vault-pki/tasks/main.yml
+++ b/roles/vault-pki/tasks/main.yml
@@ -57,7 +57,7 @@
     - name: Install certificate to OS store
       include_tasks: "{{ role_path }}/../../tasks/include_role_checked.yml"
       vars:
-        role_path: "{{ role_path }}/../ansible-ca-store"
+        role: "{{ role_path }}/../ansible-ca-store"
         certificate: "{{ download_temp.path }}"
         certificate_rename: "vault.crt"
       become: yes

--- a/roles/vault-pki/tasks/main.yml
+++ b/roles/vault-pki/tasks/main.yml
@@ -55,9 +55,9 @@
         msg: "Failed to download the CA from all the URLs. Make sure they are accessible from your machine."
       when: first_working is not defined
     - name: Install certificate to OS store
-      include_role:
-        name: "{{ role_path }}/../ansible-ca-store"
+      include_tasks: "{{ role_path }}/../../tasks/include_role_checked.yml"
       vars:
+        role_path: "{{ role_path }}/../ansible-ca-store"
         certificate: "{{ download_temp.path }}"
         certificate_rename: "vault.crt"
       become: yes

--- a/tasks/assert_local_file.yml
+++ b/tasks/assert_local_file.yml
@@ -1,3 +1,4 @@
+---
 - name: Check for {{ file }}
   local_action: "stat path={{ file }}"
   register: st

--- a/tasks/assert_local_file.yml
+++ b/tasks/assert_local_file.yml
@@ -1,6 +1,6 @@
 - name: Check for {{ file }}
   local_action: "stat path={{ file }}"
   register: st
-- fail:
+- assert:
+    that: st.stat.exists
     msg: "{{ file }} does not exist, aborting..."
-  when: not st.stat.exists

--- a/tasks/assert_local_file.yml
+++ b/tasks/assert_local_file.yml
@@ -1,0 +1,6 @@
+- name: Check for {{ file }}
+  local_action: "stat path={{ file }}"
+  register: st
+- fail:
+    msg: "{{ file }} does not exist, aborting..."
+  when: not st.stat.exists

--- a/tasks/include_role_checked.yml
+++ b/tasks/include_role_checked.yml
@@ -1,34 +1,35 @@
+---
 # Tasks (opinionated, checks by default)
 - name: Check for Tasks file
   include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/tasks/{{ tasks_file | default('main.yml') }}"
+    file: "{{ role }}/tasks/{{ tasks_file | default('main.yml') }}"
   when: tasks_check is undefined or tasks_check
 
 # Defaults
 - name: Check for Defaults file
   include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/defaults/{{ defaults_file | default('main.yml') }}"
+    file: "{{ role }}/defaults/{{ defaults_file | default('main.yml') }}"
   when: defaults_check is defined and defaults_check
 
 # Vars
 - name: Check for Vars file
   include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/vars/{{ vars_file | default('main.yml') }}"
+    file: "{{ role }}/vars/{{ vars_file | default('main.yml') }}"
   when: vars_check is defined and vars_check
 
 # Meta
 - name: Check for Meta file
   include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/meta/{{ meta_file | default('main.yml') }}"
+    file: "{{ role }}/meta/{{ meta_file | default('main.yml') }}"
   when: meta_check is defined and meta_check
 
-- name: Include role at {{ role_path }}
+- name: Include role at {{ role }}
   include_role:
     tasks_from: "{{ tasks_file | default('main.yml') }}"
     defaults_from: "{{ defaults_file | default('main.yml') }}"
     vars_from: "{{ vars_file | default('main.yml') }}"
-    name: "{{ role_path }}"
+    name: "{{ role }}"

--- a/tasks/include_role_checked.yml
+++ b/tasks/include_role_checked.yml
@@ -1,0 +1,37 @@
+- set_fact:
+    check_tasks: true
+    tasks_file: main.yml
+    check_defaults: false
+    defaults_file: main.yml
+    check_vars: false
+    vars_file: main.yml
+    check_meta: false
+    meta_file: main.yml
+
+# Tasks
+- include_tasks: assert_local_file.yml
+  vars:
+    file: "{{ role_path }}/tasks/{{ tasks_file }}"
+  when: check_tasks
+
+# Defaults
+- include_tasks: assert_local_file.yml
+  vars:
+    file: "{{ role_path }}/defaults/{{ defaults_file }}"
+  when: check_defaults
+
+# Vars
+- include_tasks: assert_local_file.yml
+  vars:
+    file: "{{ role_path }}/vars/{{ vars_file }}"
+  when: check_vars
+
+# Meta
+- include_tasks: assert_local_file.yml
+  vars:
+    file: "{{ role_path }}/meta/{{ meta_file }}"
+  when: check_meta
+
+- name: Include role at {{ role_path }}
+  include_role:
+    name: "{{ role_path }}"

--- a/tasks/include_role_checked.yml
+++ b/tasks/include_role_checked.yml
@@ -1,37 +1,34 @@
-- set_fact:
-    check_tasks: true
-    tasks_file: main.yml
-    check_defaults: false
-    defaults_file: main.yml
-    check_vars: false
-    vars_file: main.yml
-    check_meta: false
-    meta_file: main.yml
-
-# Tasks
-- include_tasks: assert_local_file.yml
+# Tasks (opinionated, checks by default)
+- name: Check for Tasks file
+  include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/tasks/{{ tasks_file }}"
-  when: check_tasks
+    file: "{{ role_path }}/tasks/{{ tasks_file | default('main.yml') }}"
+  when: tasks_check is undefined or tasks_check
 
 # Defaults
-- include_tasks: assert_local_file.yml
+- name: Check for Defaults file
+  include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/defaults/{{ defaults_file }}"
-  when: check_defaults
+    file: "{{ role_path }}/defaults/{{ defaults_file | default('main.yml') }}"
+  when: defaults_check is defined and defaults_check
 
 # Vars
-- include_tasks: assert_local_file.yml
+- name: Check for Vars file
+  include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/vars/{{ vars_file }}"
-  when: check_vars
+    file: "{{ role_path }}/vars/{{ vars_file | default('main.yml') }}"
+  when: vars_check is defined and vars_check
 
 # Meta
-- include_tasks: assert_local_file.yml
+- name: Check for Meta file
+  include_tasks: assert_local_file.yml
   vars:
-    file: "{{ role_path }}/meta/{{ meta_file }}"
-  when: check_meta
+    file: "{{ role_path }}/meta/{{ meta_file | default('main.yml') }}"
+  when: meta_check is defined and meta_check
 
 - name: Include role at {{ role_path }}
   include_role:
+    tasks_from: "{{ tasks_file | default('main.yml') }}"
+    defaults_from: "{{ defaults_file | default('main.yml') }}"
+    vars_from: "{{ vars_file | default('main.yml') }}"
     name: "{{ role_path }}"


### PR DESCRIPTION
Fixes https://github.com/GovTechSG/terraform-modules/issues/135.

Only apply to `ansible-ca-store` and `ansible-docker-ubuntu` as these are the only two submodule roles, and  performing the check makes the log a little more verbose when building.

Task instead of Role is used for the custom functionality because `include_task` will fail when the exact task file is missing, while `include_role` has that weird issue where a missing task file can completely work without warning.