### PR TITLE
Use splat syntax instead to avoid warning

### DIFF
--- a/modules/nomad-acl/outputs.tf
+++ b/modules/nomad-acl/outputs.tf
@@ -1,4 +1,4 @@
 output "path" {
   description = "Path to the Nomad secrets engine. Useful for implicit dependencies"
-  value       = "${vault_mount.nomad.path}"
+  value       = "${element(coalescelist(vault_mount.nomad.*.path, list("")), 0)}"
 }


### PR DESCRIPTION
Resource defined in: https://github.com/GovTechSG/terraform-modules/blob/846fb4ff4e4726974891a46f3bfc01ce8e11cb89/modules/nomad-acl/main.tf#L23