### PR TITLE
Fix update apt cache

### DIFF
--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -71,8 +71,11 @@
     ],
     "provisioners": [
         {
+            "type": "shell",
+            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+        },
+        {
             "type": "ansible",
-            "pause_before": "10s",
             "playbook_file": "{{ template_dir }}/site.yml",
             "user": "ubuntu",
             "extra_arguments": [

--- a/modules/core/packer/consul/packer.json
+++ b/modules/core/packer/consul/packer.json
@@ -72,7 +72,7 @@
     "provisioners": [
         {
             "type": "shell",
-            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+            "inline": ["timeout 60s bash -c \"while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done\""]
         },
         {
             "type": "ansible",

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -89,7 +89,7 @@
     "provisioners": [
         {
             "type": "shell",
-            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+            "inline": ["timeout 60s bash -c \"while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done\""]
         },
         {
             "type": "ansible",

--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -88,8 +88,11 @@
     ],
     "provisioners": [
         {
+            "type": "shell",
+            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+        },
+        {
             "type": "ansible",
-            "pause_before": "10s",
             "playbook_file": "{{ template_dir }}/site.yml",
             "user": "ubuntu",
             "extra_arguments": [

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -81,8 +81,11 @@
     ],
     "provisioners": [
         {
+            "type": "shell",
+            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+        },
+        {
             "type": "ansible",
-            "pause_before": "10s",
             "playbook_file": "{{ template_dir }}/site.yml",
             "user": "ubuntu",
             "extra_arguments": [

--- a/modules/core/packer/nomad_servers/packer.json
+++ b/modules/core/packer/nomad_servers/packer.json
@@ -82,7 +82,7 @@
     "provisioners": [
         {
             "type": "shell",
-            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+            "inline": ["timeout 60s bash -c \"while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done\""]
         },
         {
             "type": "ansible",

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -21,22 +21,11 @@
     consul_integration_prefix: "terraform/"
     nomad_additional_config: []
   pre_tasks:
-  - name: Echo /etc/apt/sources.list
-    command: cat /etc/apt/sources.list
-    register: source1
-  - debug: msg="{{ source1.stdout }}"
-
   - name: Upgrade all packages to the latest version
     apt:
       upgrade: yes
       update_cache: yes
     become: yes
-
-  - name: Echo cached packages
-    command: apt-cache policy
-    register: source2
-  - debug: msg="{{ source2.stdout }}"
-
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -21,11 +21,22 @@
     consul_integration_prefix: "terraform/"
     nomad_additional_config: []
   pre_tasks:
+  - name: Echo /etc/apt/sources.list
+    command: cat /etc/apt/sources.list
+    register: source1
+  - debug: msg="{{ source1.stdout }}"
+
   - name: Upgrade all packages to the latest version
     apt:
       upgrade: yes
       update_cache: yes
     become: yes
+
+  - name: Echo cached packages
+    command: apt-cache policy
+    register: source2
+  - debug: msg="{{ source2.stdout }}"
+
   - name: Install CA Certificate
     include_tasks: "{{ playbook_dir }}/../../../../tasks/include_role_checked.yml"
     vars:

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -81,7 +81,7 @@
     "provisioners": [
         {
             "type": "shell",
-            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+            "inline": ["timeout 60s bash -c \"while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done\""]
         },
         {
             "type": "ansible",

--- a/modules/core/packer/vault/packer.json
+++ b/modules/core/packer/vault/packer.json
@@ -80,8 +80,11 @@
     ],
     "provisioners": [
         {
+            "type": "shell",
+            "inline": ["while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done"]
+        },
+        {
             "type": "ansible",
-            "pause_before": "10s",
             "playbook_file": "{{ template_dir }}/site.yml",
             "user": "ubuntu",
             "extra_arguments": [

--- a/roles/td-agent/tasks/main.yml
+++ b/roles/td-agent/tasks/main.yml
@@ -10,17 +10,10 @@
 - name: Install dependencies for td-agent
   apt:
     name: "{{ item }}"
-    update_cache: yes
   with_items:
   - gcc
   - make
   become: yes
-  register: result
-  # Workaround for `No package matching 'gcc' is available`
-  # See https://github.com/GovTechSG/terraform-modules/issues/169
-  retries: 10
-  delay: 10
-  until: not result.failed
 - name: Run the install script
   command: "sh {{ td_agent_tmp_file }}"
   become: yes


### PR DESCRIPTION
Resolves https://github.com/GovTechSG/terraform-modules/issues/169.

Tested a total of 20 packer runs on all `consul-server`, `nomad-server`, `nomad-client`, `vault`, no more errors found during the installation of `td-agent` `gcc` package.

Also no need to wait for 10s, since the completion of `cloud-init` should ensure that the instance is ready to go.