### PR TITLE
Set proxy_protocol_behavior in Vault

### DIFF
--- a/roles/vault/files/config/override.hcl
+++ b/roles/vault/files/config/override.hcl
@@ -3,3 +3,4 @@ ha_storage "consul" {
 }
 
 ui = "{{ vault_ui_enable }}"
+proxy_protocol_behavior = "use_always"


### PR DESCRIPTION
See [documentation](https://www.vaultproject.io/docs/configuration/listener/tcp.html#proxy_protocol_behavior).

This is so that the remote client address logged in Vault will be accurate when the requests are sent through ELB.

Also allows to limit the usage of tokens to certain CIDRs.