### PR TITLE
Configure Vault ELB X-Forwarded-For 

### DIFF
--- a/modules/core/data.tf
+++ b/modules/core/data.tf
@@ -7,3 +7,9 @@ data "aws_region" "current" {}
 data "aws_vpc" "this" {
   id = "${var.vpc_id}"
 }
+
+data "aws_subnet" "internal_lb_subnets" {
+  count = "${length(var.internal_lb_subnets)}"
+
+  id = "${element(var.internal_lb_subnets, count.index)}"
+}

--- a/modules/core/elb.tf
+++ b/modules/core/elb.tf
@@ -268,7 +268,7 @@ resource "aws_lb_listener_rule" "vault" {
 
 resource "aws_lb_target_group" "vault" {
   name                 = "${var.internal_lb_name}-vault"
-  port                 = "${local.vault_api_port}"
+  port                 = "${local.vault_lb_port}"
   protocol             = "HTTPS"
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = "${var.vault_lb_deregistration_delay}"
@@ -280,7 +280,7 @@ resource "aws_lb_target_group" "vault" {
     unhealthy_threshold = "${var.vault_lb_unhealthy_threshold}"
     protocol            = "HTTPS"
     path                = "/v1/sys/health?standbyok=true"
-    port                = "${local.vault_api_port}"
+    port                = "${local.vault_lb_port}"
     interval            = "${var.vault_lb_interval}"
   }
 
@@ -301,8 +301,8 @@ resource "aws_autoscaling_attachment" "vault_internal" {
 resource "aws_security_group_rule" "vault_api_outgoing" {
   type                     = "egress"
   security_group_id        = "${aws_security_group.internal_lb.id}"
-  from_port                = "${local.vault_api_port}"
-  to_port                  = "${local.vault_api_port}"
+  from_port                = "${local.vault_lb_port}"
+  to_port                  = "${local.vault_lb_port}"
   protocol                 = "tcp"
   source_security_group_id = "${module.vault.security_group_id}"
 }
@@ -311,8 +311,8 @@ resource "aws_security_group_rule" "vault_api_outgoing" {
 resource "aws_security_group_rule" "vault_https" {
   type                     = "ingress"
   security_group_id        = "${module.vault.security_group_id}"
-  from_port                = "${local.vault_api_port}"
-  to_port                  = "${local.vault_api_port}"
+  from_port                = "${local.vault_lb_port}"
+  to_port                  = "${local.vault_lb_port}"
   protocol                 = "tcp"
   source_security_group_id = "${aws_security_group.internal_lb.id}"
 }

--- a/modules/core/user_data/user-data-vault.sh
+++ b/modules/core/user_data/user-data-vault.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 readonly service_type="vault"
 readonly marker_path="/etc/user-data-marker"
 
+# The Packer template puts the TLS certs in these file paths
+readonly VAULT_TLS_CERT_FILE="${cert_file}"
+readonly VAULT_TLS_KEY_FILE="${cert_key}"
+
 # Send the log output from this script to user-data.log, syslog, and the console
 # From: https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
@@ -46,11 +50,11 @@ AWS_DEFAULT_REGION="${aws_region}" \
     --consul-prefix "${consul_prefix}"
 
 /opt/vault/bin/configure \
-    --consul-prefix "${consul_prefix}"
-
-# The Packer template puts the TLS certs in these file paths
-readonly VAULT_TLS_CERT_FILE="${cert_file}"
-readonly VAULT_TLS_KEY_FILE="${cert_key}"
+    --consul-prefix "${consul_prefix}" \
+    --tls-cert-file "$VAULT_TLS_CERT_FILE"  \
+    --tls-key-file "$VAULT_TLS_KEY_FILE" \
+    --lb-listener-port "${lb_listener_port}" \
+    --x-forwarded-for-addrs "${lb_cidr}"
 
 if [ "${enable_s3_backend}" = "true" ] ; then
     /opt/vault/bin/run-vault \

--- a/modules/core/vault.tf
+++ b/modules/core/vault.tf
@@ -5,6 +5,9 @@
 locals {
   vault_api_port  = 8200
   vault_user_data = "${coalesce(var.vault_user_data, data.template_file.user_data_vault_cluster.rendered)}"
+
+  # Port for connection between the ELB and Vault
+  vault_lb_port = 8300
 }
 
 module "vault" {
@@ -77,6 +80,9 @@ data "template_file" "user_data_vault_cluster" {
     s3_bucket_name    = "${var.vault_s3_bucket_name}"
 
     consul_prefix = "${var.integration_consul_prefix}"
+
+    lb_listener_port = "${local.vault_lb_port}"
+    lb_cidr          = "${join(",", data.aws_subnet.internal_lb_subnets.*.cidr_block)}"
   }
 }
 

--- a/roles/ansible/defaults/main.yml
+++ b/roles/ansible/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ansible_install_version: "2.6.4"
+ansible_install_version: "2.7.0"

--- a/roles/vault/files/config/override.hcl
+++ b/roles/vault/files/config/override.hcl
@@ -3,4 +3,3 @@ ha_storage "consul" {
 }
 
 ui = "{{ vault_ui_enable }}"
-proxy_protocol_behavior = "use_always"

--- a/roles/vault/files/config/override.hcl
+++ b/roles/vault/files/config/override.hcl
@@ -3,3 +3,4 @@ ha_storage "consul" {
 }
 
 ui = "{{ vault_ui_enable }}"
+proxy_protocol_behavior = "use_always"


### PR DESCRIPTION
- Currently, the requesting IP addresses for all Vault requests going through the ELB is the ELB IP address
- This cause issues if we want to restrict the incoming CIDRs
- Create an additional listener specifically for ELB
- Use security group rules to only allow connections between ELB and this new listener port
- Configure this listener in Vault to only accept `X-Forwarded-For` headers from the subnet CIDRs of the ELB.
- Requests going through the ELB now has the correct source IP attribution