### PR TITLE
Remove default empty values for LB log buckets

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -488,7 +488,7 @@ Replace `xxx` with the instance ID.
 | consul_termination_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default. | string | `NewestInstance` | no |
 | consul_user_data | The user data for the Consul servers EC2 instances. If set to empty, the default template will be used | string | `` | no |
 | elb_access_log | Log Internal LB access to a S3 bucket | string | `false` | no |
-| elb_access_log_bucket | S3 bucket to log access to the internal LB to | string | `` | no |
+| elb_access_log_bucket | S3 bucket to log access to the internal LB to | string | - | yes |
 | elb_access_log_prefix | Prefix in the S3 bucket to log internal LB access | string | `` | no |
 | elb_ssl_policy | ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html | string | `ELBSecurityPolicy-TLS-1-2-2017-01` | no |
 | integration_consul_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | string | `terraform/` | no |
@@ -568,8 +568,10 @@ Replace `xxx` with the instance ID.
 | iam_role_id_consul_servers | IAM Role ID for Consul servers |
 | iam_role_id_nomad_clients | IAM Role ID for Nomad Clients |
 | iam_role_id_nomad_servers | IAM Role ID for Nomad servers |
+| internal_lb_dns_name | DNS name of the internal LB |
 | internal_lb_https_listener_arn | ARN of the HTTPS listener for the internal LB |
-| internal_lb_id | ID of the internal LB that exposes Nomad, Consul and Vault RPC |
+| internal_lb_id | ARN of the internal LB that exposes Nomad, Consul and Vault RPC |
+| internal_lb_zone_id | The canonical hosted zone ID of the internal load balancer |
 | launch_config_name_consul_servers | Name of the Launch Configuration for Consul servers |
 | launch_config_name_nomad_clients | Name of the Launch Configuration for Nomad Clients |
 | launch_config_name_nomad_servers | Name of Launch Configuration for Nomad servers |

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -426,7 +426,6 @@ variable "elb_access_log" {
 
 variable "elb_access_log_bucket" {
   description = "S3 bucket to log access to the internal LB to"
-  default     = ""
 }
 
 variable "elb_access_log_prefix" {

--- a/modules/core/vault-helper.sh
+++ b/modules/core/vault-helper.sh
@@ -14,7 +14,7 @@ readonly SCRIPT_NAME="$(basename "$0")"
 readonly MAX_RETRIES=30
 readonly SLEEP_BETWEEN_RETRIES_SEC=10
 
-TERRAFORM="${TERRAFORM:-terraform}"
+TERRAFORM="${TERRAFORM:-terragrunt}"
 
 function log {
   local readonly level="$1"

--- a/modules/core/vault-helper.sh
+++ b/modules/core/vault-helper.sh
@@ -14,7 +14,7 @@ readonly SCRIPT_NAME="$(basename "$0")"
 readonly MAX_RETRIES=30
 readonly SLEEP_BETWEEN_RETRIES_SEC=10
 
-TERRAFORM="${TERRAFORM:-terragrunt}"
+TERRAFORM="${TERRAFORM:-terraform}"
 
 function log {
   local readonly level="$1"

--- a/modules/traefik/README.md
+++ b/modules/traefik/README.md
@@ -138,11 +138,11 @@ job "hashi-ui" {
 | internal_nomad_clients_asg | The Nomad Clients Autoscaling group to attach the internal load balancer to | string | - | yes |
 | interval | The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. | string | `30` | no |
 | lb_external_access_log | Log External Traefik LB access to a S3 bucket | string | `false` | no |
-| lb_external_access_log_bucket | S3 bucket to log access to the External Traefik LB to | string | `` | no |
+| lb_external_access_log_bucket | S3 bucket to log access to the External Traefik LB to | string | - | yes |
 | lb_external_access_log_prefix | Prefix in the S3 bucket to log External Traefik LB access | string | `` | no |
 | lb_external_subnets | List of subnets to deploy the external LB to | list | - | yes |
 | lb_internal_access_log | Log internal Traefik LB access to a S3 bucket | string | `false` | no |
-| lb_internal_access_log_bucket | S3 bucket to log access to the internal Traefik LB to | string | `` | no |
+| lb_internal_access_log_bucket | S3 bucket to log access to the internal Traefik LB to | string | - | yes |
 | lb_internal_access_log_prefix | Prefix in the S3 bucket to log internal Traefik LB access | string | `` | no |
 | lb_internal_subnets | List of subnets to deploy the internal LB to | list | - | yes |
 | log_json | Log in JSON format | string | `false` | no |

--- a/modules/traefik/variables.tf
+++ b/modules/traefik/variables.tf
@@ -173,7 +173,6 @@ variable "lb_external_access_log" {
 
 variable "lb_external_access_log_bucket" {
   description = "S3 bucket to log access to the External Traefik LB to"
-  default     = ""
 }
 
 variable "lb_external_access_log_prefix" {
@@ -188,7 +187,6 @@ variable "lb_internal_access_log" {
 
 variable "lb_internal_access_log_bucket" {
   description = "S3 bucket to log access to the internal Traefik LB to"
-  default     = ""
 }
 
 variable "lb_internal_access_log_prefix" {


### PR DESCRIPTION
Remove all default values for LB log buckets since missing values give a clearer picture that the values are required no matter what.

Also fix Vault inventory finding.