### PR TITLE
Fix errors in Elasticsearch Alarms

### DIFF
--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -108,29 +108,19 @@ module "es" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| KMS_key_error_alarm_name | Name of the alarm | string | `KMS_key_error_alarm` | no |
-| KMS_key_error_enable | Whether to enable alarm | string | `true` | no |
-| KMS_key_error_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
-| KMS_key_error_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
-| KMS_key_error_threshold | Threshold for the number of KMS key error | string | `1` | no |
-| KMS_key_inaccessible_alarm_name | Name of the alarm | string | `KMS_key_inaccessible_alarm` | no |
-| KMS_key_inaccessible_enable | Whether to enable alarm | string | `true` | no |
-| KMS_key_inaccessible_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
-| KMS_key_inaccessible_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
-| KMS_key_inaccessible_threshold | Threshold for the number of KMS key inaccessible error | string | `1` | no |
-| alarm_action | A list of ARNs (i.e. SNS Topic ARN) to notify for alarm action | string | `<list>` | no |
+| alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for alarm action | list | `<list>` | no |
 | cluster_index_writes_blocked_alarm_name | Name of the alarm | string | `cluster_index_writes_blocked_alarm` | no |
 | cluster_index_writes_blocked_enable | Whether to enable alarm | string | `true` | no |
 | cluster_index_writes_blocked_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_index_writes_blocked_period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | cluster_index_writes_blocked_threshold | Threshold for the number of write request blocked | string | `1` | no |
 | cluster_status_red_alarm_name | Name of the alarm. | string | `cluster_status_red_alarm` | no |
-| cluster_status_red_enabled | Whether to enable alarm | string | `true` | no |
+| cluster_status_red_enable | Whether to enable alarm | string | `true` | no |
 | cluster_status_red_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_status_red_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | cluster_status_red_threshold | Threshold for the number of primary shard not allocated to a node | string | `1` | no |
 | cluster_status_yellow_alarm_name | Name of the alarm | string | `cluster_status_yellow_alarm` | no |
-| cluster_status_yellow_enabled | Whether to enable alarm | string | `true` | no |
+| cluster_status_yellow_enable | Whether to enable alarm | string | `true` | no |
 | cluster_status_yellow_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_status_yellow_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | cluster_status_yellow_threshold | Threshold for the number of replicas shard not allocated to a node | string | `1` | no |
@@ -148,7 +138,7 @@ module "es" {
 | es_http_iam_roles | List of IAM role ARNs from which to permit Elasticsearch HTTP traffic (default ['*']). Note that a client must match both the IP address and the IAM role patterns in order to be permitted access. | list | `<list>` | no |
 | es_instance_count | Number of nodes to be deployed in Elasticsearch | string | - | yes |
 | es_instance_type | Elasticsearch instance type for non-master node | string | - | yes |
-| es_kms_key_id | KMS Key ID for encryption at rest. Defaults to AWS service key. | string | `aws/es` | no |
+| es_kms_key_id | kms Key ID for encryption at rest. Defaults to AWS service key. | string | `aws/es` | no |
 | es_master_type | Elasticsearch instance type for dedicated master node | string | - | yes |
 | es_snapshot_start_hour | Hour at which automated snapshots are taken, in UTC (default 0) | string | `19` | no |
 | es_version | Elasticsearch version to deploy | string | `5.5` | no |
@@ -174,9 +164,19 @@ module "es" {
 | high_jvm_memory_utilization_master_node_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | high_jvm_memory_utilization_master_node_period | Duration in seconds to evaluate for the alarm. | string | `900` | no |
 | high_jvm_memory_utilization_master_node_threshold | Threshold % of jvm memory utilization for master node | string | `80` | no |
+| kms_key_error_alarm_name | Name of the alarm | string | `kms_key_error_alarm` | no |
+| kms_key_error_enable | Whether to enable alarm | string | `true` | no |
+| kms_key_error_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
+| kms_key_error_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
+| kms_key_error_threshold | Threshold for the number of kms key error | string | `1` | no |
+| kms_key_inaccessible_alarm_name | Name of the alarm | string | `kms_key_inaccessible_alarm` | no |
+| kms_key_inaccessible_enable | Whether to enable alarm | string | `true` | no |
+| kms_key_inaccessible_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
+| kms_key_inaccessible_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
+| kms_key_inaccessible_threshold | Threshold for the number of kms key inaccessible error | string | `1` | no |
 | lb_cname | DNS CNAME for the Load balancer | string | `` | no |
 | lb_zone_id | Zone ID for the Load balancer DNS CNAME | string | `` | no |
-| low_storage_space_enabled | Whether to enable alarm | string | `true` | no |
+| low_storage_space_enable | Whether to enable alarm | string | `true` | no |
 | low_storage_space_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | low_storage_space_name | Name of the alarm | string | `low_storage_space_alarm` | no |
 | low_storage_space_yellow_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
@@ -184,7 +184,7 @@ module "es" {
 | node_unreachable_enable | Whether to enable alarm | string | `true` | no |
 | node_unreachable_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | node_unreachable_period | Duration in seconds to evaluate for the alarm. | string | `86400` | no |
-| ok_action | A list of ARNs (i.e. SNS Topic ARN) to notify for ok action | string | `<list>` | no |
+| ok_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for ok action | list | `<list>` | no |
 | redirect_domain | Domain name to redirect | string | `` | no |
 | redirect_listener_arn | LB listener ARN to attach the rule to | string | `` | no |
 | redirect_route53_zone_id | Route53 Zone ID to create the Redirect Record in | string | `` | no |
@@ -201,7 +201,6 @@ module "es" {
 | snapshot_failed_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | snapshot_failed_threshold | Threshold for the number of snapshot failed | string | `1` | no |
 | use_redirect | Indicates whether to use redirect users | string | `false` | no |
-
 
 ## Outputs
 

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -110,17 +110,17 @@ module "es" {
 |------|-------------|:----:|:-----:|:-----:|
 | alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for alarm action | list | `<list>` | no |
 | cluster_index_writes_blocked_alarm_name | Name of the alarm | string | `cluster_index_writes_blocked_alarm` | no |
-| cluster_index_writes_blocked_enable | Whether to enable alarm | string | `true` | no |
+| cluster_index_writes_blocked_enable | Whether to enable alarm | string | `false` | no |
 | cluster_index_writes_blocked_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_index_writes_blocked_period | Duration in seconds to evaluate for the alarm. | string | `300` | no |
 | cluster_index_writes_blocked_threshold | Threshold for the number of write request blocked | string | `1` | no |
 | cluster_status_red_alarm_name | Name of the alarm. | string | `cluster_status_red_alarm` | no |
-| cluster_status_red_enable | Whether to enable alarm | string | `true` | no |
+| cluster_status_red_enable | Whether to enable alarm | string | `false` | no |
 | cluster_status_red_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_status_red_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | cluster_status_red_threshold | Threshold for the number of primary shard not allocated to a node | string | `1` | no |
 | cluster_status_yellow_alarm_name | Name of the alarm | string | `cluster_status_yellow_alarm` | no |
-| cluster_status_yellow_enable | Whether to enable alarm | string | `true` | no |
+| cluster_status_yellow_enable | Whether to enable alarm | string | `false` | no |
 | cluster_status_yellow_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | cluster_status_yellow_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | cluster_status_yellow_threshold | Threshold for the number of replicas shard not allocated to a node | string | `1` | no |
@@ -145,43 +145,43 @@ module "es" {
 | es_vpc_subnet_ids | Subnet IDs for Elasticsearch cluster | list | - | yes |
 | es_zone_awareness | Enable zone awareness for Elasticsearch cluster | string | `true` | no |
 | high_cpu_utilization_data_node_alarm_name | Name of the alarm | string | `high_cpu_utilization_data_node_alarm` | no |
-| high_cpu_utilization_data_node_enable | Whether to enable alarm | string | `true` | no |
+| high_cpu_utilization_data_node_enable | Whether to enable alarm | string | `false` | no |
 | high_cpu_utilization_data_node_evaluation_periods | Number of periods to evaluate for the alarm. | string | `3` | no |
 | high_cpu_utilization_data_node_period | Duration in seconds to evaluate for the alarm. | string | `900` | no |
 | high_cpu_utilization_data_node_threshold | Threshold % of cpu utilization for data node | string | `80` | no |
 | high_cpu_utilization_master_node_alarm_name | Name of the alarm | string | `high_cpu_utilization_master_node_alarm` | no |
-| high_cpu_utilization_master_node_enable | Whether to enable alarm | string | `true` | no |
+| high_cpu_utilization_master_node_enable | Whether to enable alarm | string | `false` | no |
 | high_cpu_utilization_master_node_evaluation_periods | Number of periods to evaluate for the alarm. | string | `3` | no |
 | high_cpu_utilization_master_node_period | Duration in seconds to evaluate for the alarm. | string | `900` | no |
 | high_cpu_utilization_master_node_threshold | Threshold % of cpu utilization for master node | string | `50` | no |
 | high_jvm_memory_utilization_data_node_alarm_name | Name of the alarm | string | `high_jvm_memory_utilization_data_node_alarm` | no |
-| high_jvm_memory_utilization_data_node_enable | Whether to enable alarm | string | `true` | no |
+| high_jvm_memory_utilization_data_node_enable | Whether to enable alarm | string | `false` | no |
 | high_jvm_memory_utilization_data_node_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | high_jvm_memory_utilization_data_node_period | Duration in seconds to evaluate for the alarm. | string | `900` | no |
 | high_jvm_memory_utilization_data_node_threshold | Threshold % of jvm memory utilization for data node | string | `80` | no |
 | high_jvm_memory_utilization_master_node_alarm_name | Name of the alarm | string | `high_jvm_memory_utilization_master_node_alarm` | no |
-| high_jvm_memory_utilization_master_node_enable | Whether to enable alarm | string | `true` | no |
+| high_jvm_memory_utilization_master_node_enable | Whether to enable alarm | string | `false` | no |
 | high_jvm_memory_utilization_master_node_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | high_jvm_memory_utilization_master_node_period | Duration in seconds to evaluate for the alarm. | string | `900` | no |
 | high_jvm_memory_utilization_master_node_threshold | Threshold % of jvm memory utilization for master node | string | `80` | no |
 | kms_key_error_alarm_name | Name of the alarm | string | `kms_key_error_alarm` | no |
-| kms_key_error_enable | Whether to enable alarm | string | `true` | no |
+| kms_key_error_enable | Whether to enable alarm | string | `false` | no |
 | kms_key_error_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | kms_key_error_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | kms_key_error_threshold | Threshold for the number of kms key error | string | `1` | no |
 | kms_key_inaccessible_alarm_name | Name of the alarm | string | `kms_key_inaccessible_alarm` | no |
-| kms_key_inaccessible_enable | Whether to enable alarm | string | `true` | no |
+| kms_key_inaccessible_enable | Whether to enable alarm | string | `false` | no |
 | kms_key_inaccessible_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | kms_key_inaccessible_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | kms_key_inaccessible_threshold | Threshold for the number of kms key inaccessible error | string | `1` | no |
 | lb_cname | DNS CNAME for the Load balancer | string | `` | no |
 | lb_zone_id | Zone ID for the Load balancer DNS CNAME | string | `` | no |
-| low_storage_space_enable | Whether to enable alarm | string | `true` | no |
+| low_storage_space_enable | Whether to enable alarm | string | `false` | no |
 | low_storage_space_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | low_storage_space_name | Name of the alarm | string | `low_storage_space_alarm` | no |
 | low_storage_space_yellow_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | node_unreachable_alarm_name | Name of the alarm | string | `node_unreachable_enable_alarm` | no |
-| node_unreachable_enable | Whether to enable alarm | string | `true` | no |
+| node_unreachable_enable | Whether to enable alarm | string | `false` | no |
 | node_unreachable_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | node_unreachable_period | Duration in seconds to evaluate for the alarm. | string | `86400` | no |
 | ok_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for ok action | list | `<list>` | no |
@@ -196,7 +196,7 @@ module "es" {
 | slow_index_log_name | Name of the Cloudwatch log group for slow index | string | `es-slow-index` | no |
 | slow_index_log_retention | Number of days to retain logs for. | string | `120` | no |
 | snapshot_failed_alarm_name | Name of the alarm | string | `snapshot_failed_alarm` | no |
-| snapshot_failed_enable | Whether to enable alarm | string | `true` | no |
+| snapshot_failed_enable | Whether to enable alarm | string | `false` | no |
 | snapshot_failed_evaluation_periods | Number of periods to evaluate for the alarm. | string | `1` | no |
 | snapshot_failed_period | Duration in seconds to evaluate for the alarm. | string | `60` | no |
 | snapshot_failed_threshold | Threshold for the number of snapshot failed | string | `1` | no |

--- a/modules/elasticsearch/alarm.tf
+++ b/modules/elasticsearch/alarm.tf
@@ -10,8 +10,8 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_red" {
   statistic           = "Maximum"
   threshold           = "${var.cluster_status_red_threshold}"
   alarm_description   = "At least one primary shard and its replicas are not allocated to a node"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cluster_status_yellow" {
@@ -26,8 +26,8 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_yellow" {
   statistic           = "Maximum"
   threshold           = "${var.cluster_status_yellow_threshold}"
   alarm_description   = "At least one replica shard is not allocated to a node"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "low_storage_space" {
@@ -42,8 +42,8 @@ resource "aws_cloudwatch_metric_alarm" "low_storage_space" {
   statistic           = "Minimum"
   threshold           = "${var.es_ebs_volume_size * 256}"
   alarm_description   = "Less than 25% of ${var.es_ebs_volume_size} storage space available"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
@@ -55,10 +55,11 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
   metric_name         = "ClusterIndexWritesBlocked"
   namespace           = "AWS/ES"
   period              = "${var.cluster_index_writes_blocked_period}"
+  statistic           = "SampleCount"
   threshold           = "${var.cluster_index_writes_blocked_threshold}"
   alarm_description   = "Cluster is blocking write request due to lack of available storage space or memory"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "node_unreachable" {
@@ -73,8 +74,8 @@ resource "aws_cloudwatch_metric_alarm" "node_unreachable" {
   statistic           = "Minimum"
   threshold           = "${var.es_instance_count}"
   alarm_description   = "Node in your cluster has been unreachable for one day."
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "snapshot_failed" {
@@ -89,8 +90,8 @@ resource "aws_cloudwatch_metric_alarm" "snapshot_failed" {
   statistic           = "Maximum"
   threshold           = "${var.snapshot_failed_threshold}"
   alarm_description   = "An automated snapshot failed"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization_data_node" {
@@ -105,8 +106,8 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization_data_node" {
   statistic           = "Average"
   threshold           = "${var.high_cpu_utilization_master_node_threshold}"
   alarm_description   = "High cpu utilization for 15mins"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_jvm_memory_utilization_data_node" {
@@ -121,8 +122,8 @@ resource "aws_cloudwatch_metric_alarm" "high_jvm_memory_utilization_data_node" {
   statistic           = "Maximum"
   threshold           = "${var.high_jvm_memory_utilization_data_node_threshold}"
   alarm_description   = "High JVM memory utilization for 15mins"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization_master_node" {
@@ -137,8 +138,8 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization_master_node" {
   statistic           = "Average"
   threshold           = "${var.high_cpu_utilization_master_node_threshold}"
   alarm_description   = "High cpu utilization for master node"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_jvm_memory_utilization_master_node" {
@@ -153,36 +154,38 @@ resource "aws_cloudwatch_metric_alarm" "high_jvm_memory_utilization_master_node"
   statistic           = "Maximum"
   threshold           = "${var.high_jvm_memory_utilization_master_node_threshold}"
   alarm_description   = "High JVM memory utilization for 15mins"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "KMS_key_error" {
-  count = "${var.KMS_key_error_enable ? 1 : 0}"
+resource "aws_cloudwatch_metric_alarm" "kms_key_error" {
+  count = "${var.kms_key_error_enable ? 1 : 0}"
 
-  alarm_name          = "${var.KMS_key_error_alarm_name}"
+  alarm_name          = "${var.kms_key_error_alarm_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.KMS_key_error_alarm_name}"
-  metric_name         = "KMSKeyError"
+  evaluation_periods  = "${var.kms_key_error_evaluation_periods}"
+  metric_name         = "kmsKeyError"
   namespace           = "AWS/ES"
-  period              = "${var.KMS_key_error_period}"
-  threshold           = "${var.KMS_key_error_threshold}"
-  alarm_description   = "The KMS encryption key that is used to encrypt data at rest in your domain is disabled"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  period              = "${var.kms_key_error_period}"
+  statistic           = "SampleCount"
+  threshold           = "${var.kms_key_error_threshold}"
+  alarm_description   = "The kms encryption key that is used to encrypt data at rest in your domain is disabled"
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }
 
-resource "aws_cloudwatch_metric_alarm" "KMS_key_inaccessible" {
-  count = "${var.KMS_key_inaccessible_enable ? 1 : 0}"
+resource "aws_cloudwatch_metric_alarm" "kms_key_inaccessible" {
+  count = "${var.kms_key_inaccessible_enable ? 1 : 0}"
 
-  alarm_name          = "${var.KMS_key_inaccessible_alarm_name}"
+  alarm_name          = "${var.kms_key_inaccessible_alarm_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.KMS_key_inaccessible_evaluation_periods}"
-  metric_name         = "KMSKeyInaccessible"
+  evaluation_periods  = "${var.kms_key_inaccessible_evaluation_periods}"
+  metric_name         = "kmsKeyInaccessible"
   namespace           = "AWS/ES"
-  period              = "${var.KMS_key_inaccessible_period}"
-  threshold           = "${var.KMS_key_inaccessible_threshold}"
-  alarm_description   = "The KMS encryption key has been deleted or has revoked its grants to Amazon ES"
-  alarm_action        = ["${var.alarm_action}"]
-  ok_action           = ["${var.ok_action}"]
+  period              = "${var.kms_key_inaccessible_period}"
+  statistic           = "SampleCount"
+  threshold           = "${var.kms_key_inaccessible_threshold}"
+  alarm_description   = "The kms encryption key has been deleted or has revoked its grants to Amazon ES"
+  alarm_actions       = ["${var.alarm_actions}"]
+  ok_actions          = ["${var.ok_actions}"]
 }

--- a/modules/elasticsearch/alarm.tf
+++ b/modules/elasticsearch/alarm.tf
@@ -164,12 +164,12 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_error" {
   alarm_name          = "${var.kms_key_error_alarm_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.kms_key_error_evaluation_periods}"
-  metric_name         = "kmsKeyError"
+  metric_name         = "KMSKeyError"
   namespace           = "AWS/ES"
   period              = "${var.kms_key_error_period}"
   statistic           = "SampleCount"
   threshold           = "${var.kms_key_error_threshold}"
-  alarm_description   = "The kms encryption key that is used to encrypt data at rest in your domain is disabled"
+  alarm_description   = "The KMS encryption key that is used to encrypt data at rest in your domain is disabled"
   alarm_actions       = ["${var.alarm_actions}"]
   ok_actions          = ["${var.ok_actions}"]
 }
@@ -180,12 +180,12 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_inaccessible" {
   alarm_name          = "${var.kms_key_inaccessible_alarm_name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.kms_key_inaccessible_evaluation_periods}"
-  metric_name         = "kmsKeyInaccessible"
+  metric_name         = "KMSKeyInaccessible"
   namespace           = "AWS/ES"
   period              = "${var.kms_key_inaccessible_period}"
   statistic           = "SampleCount"
   threshold           = "${var.kms_key_inaccessible_threshold}"
-  alarm_description   = "The kms encryption key has been deleted or has revoked its grants to Amazon ES"
+  alarm_description   = "The KMS encryption key has been deleted or has revoked its grants to Amazon ES"
   alarm_actions       = ["${var.alarm_actions}"]
   ok_actions          = ["${var.ok_actions}"]
 }

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -201,7 +201,7 @@ variable "ok_actions" {
 
 variable "cluster_status_red_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "cluster_status_red_alarm_name" {
@@ -230,7 +230,7 @@ variable "cluster_status_red_threshold" {
 
 variable "cluster_status_yellow_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "cluster_status_yellow_alarm_name" {
@@ -259,7 +259,7 @@ variable "cluster_status_yellow_threshold" {
 
 variable "low_storage_space_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "low_storage_space_name" {
@@ -283,7 +283,7 @@ variable "low_storage_space_yellow_period" {
 
 variable "cluster_index_writes_blocked_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "cluster_index_writes_blocked_alarm_name" {
@@ -312,7 +312,7 @@ variable "cluster_index_writes_blocked_threshold" {
 
 variable "node_unreachable_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "node_unreachable_alarm_name" {
@@ -336,7 +336,7 @@ variable "node_unreachable_period" {
 
 variable "snapshot_failed_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "snapshot_failed_alarm_name" {
@@ -365,7 +365,7 @@ variable "snapshot_failed_threshold" {
 
 variable "high_cpu_utilization_data_node_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "high_cpu_utilization_data_node_alarm_name" {
@@ -394,7 +394,7 @@ variable "high_cpu_utilization_data_node_threshold" {
 
 variable "high_jvm_memory_utilization_data_node_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "high_jvm_memory_utilization_data_node_alarm_name" {
@@ -423,7 +423,7 @@ variable "high_jvm_memory_utilization_data_node_threshold" {
 
 variable "high_cpu_utilization_master_node_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "high_cpu_utilization_master_node_alarm_name" {
@@ -452,7 +452,7 @@ variable "high_cpu_utilization_master_node_threshold" {
 
 variable "high_jvm_memory_utilization_master_node_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "high_jvm_memory_utilization_master_node_alarm_name" {
@@ -481,7 +481,7 @@ variable "high_jvm_memory_utilization_master_node_threshold" {
 
 variable "kms_key_error_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "kms_key_error_alarm_name" {
@@ -510,7 +510,7 @@ variable "kms_key_error_threshold" {
 
 variable "kms_key_inaccessible_enable" {
   description = "Whether to enable alarm"
-  default     = true
+  default     = false
 }
 
 variable "kms_key_inaccessible_alarm_name" {

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -107,7 +107,7 @@ variable "es_encrypt_at_rest" {
 }
 
 variable "es_kms_key_id" {
-  description = "KMS Key ID for encryption at rest. Defaults to AWS service key."
+  description = "kms Key ID for encryption at rest. Defaults to AWS service key."
   default     = "aws/es"
 }
 
@@ -183,13 +183,13 @@ variable "redirect_rule_priority" {
 # Alarm related
 # for recommended cloudwatch alert: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html
 
-variable "alarm_action" {
+variable "alarm_actions" {
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify for alarm action"
   type        = "list"
   default     = []
 }
 
-variable "ok_action" {
+variable "ok_actions" {
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify for ok action"
   type        = "list"
   default     = []
@@ -199,7 +199,7 @@ variable "ok_action" {
 # Cluster_status_red
 #
 
-variable "cluster_status_red_enabled" {
+variable "cluster_status_red_enable" {
   description = "Whether to enable alarm"
   default     = true
 }
@@ -228,7 +228,7 @@ variable "cluster_status_red_threshold" {
 # Cluster_status_yellow
 #
 
-variable "cluster_status_yellow_enabled" {
+variable "cluster_status_yellow_enable" {
   description = "Whether to enable alarm"
   default     = true
 }
@@ -257,7 +257,7 @@ variable "cluster_status_yellow_threshold" {
 # Low_storage_space
 #
 
-variable "low_storage_space_enabled" {
+variable "low_storage_space_enable" {
   description = "Whether to enable alarm"
   default     = true
 }
@@ -476,60 +476,60 @@ variable "high_jvm_memory_utilization_master_node_threshold" {
 }
 
 #
-# KMS_key_error
+# kms_key_error
 #
 
-variable "KMS_key_error_enable" {
+variable "kms_key_error_enable" {
   description = "Whether to enable alarm"
   default     = true
 }
 
-variable "KMS_key_error_alarm_name" {
+variable "kms_key_error_alarm_name" {
   description = "Name of the alarm"
-  default     = "KMS_key_error_alarm"
+  default     = "kms_key_error_alarm"
 }
 
-variable "KMS_key_error_evaluation_periods" {
+variable "kms_key_error_evaluation_periods" {
   description = "Number of periods to evaluate for the alarm."
   default     = "1"
 }
 
-variable "KMS_key_error_period" {
+variable "kms_key_error_period" {
   description = "Duration in seconds to evaluate for the alarm."
   default     = "60"
 }
 
-variable "KMS_key_error_threshold" {
-  description = "Threshold for the number of KMS key error"
+variable "kms_key_error_threshold" {
+  description = "Threshold for the number of kms key error"
   default     = "1"
 }
 
 #
-# KMS_key_inaccessible
+# kms_key_inaccessible
 #
 
-variable "KMS_key_inaccessible_enable" {
+variable "kms_key_inaccessible_enable" {
   description = "Whether to enable alarm"
   default     = true
 }
 
-variable "KMS_key_inaccessible_alarm_name" {
+variable "kms_key_inaccessible_alarm_name" {
   description = "Name of the alarm"
-  default     = "KMS_key_inaccessible_alarm"
+  default     = "kms_key_inaccessible_alarm"
 }
 
-variable "KMS_key_inaccessible_evaluation_periods" {
+variable "kms_key_inaccessible_evaluation_periods" {
   description = "Number of periods to evaluate for the alarm."
   default     = "1"
 }
 
-variable "KMS_key_inaccessible_period" {
+variable "kms_key_inaccessible_period" {
   description = "Duration in seconds to evaluate for the alarm."
   default     = "60"
 }
 
-variable "KMS_key_inaccessible_threshold" {
-  description = "Threshold for the number of KMS key inaccessible error"
+variable "kms_key_inaccessible_threshold" {
+  description = "Threshold for the number of kms key inaccessible error"
   default     = "1"
 }
 


### PR DESCRIPTION
- Variable names
- Incorrect parameters
- Missing parameters
- Disable alarms by default