### PR TITLE
`create_before_destroy` for ELB Target Groups

### DIFF
--- a/modules/traefik/external.tf
+++ b/modules/traefik/external.tf
@@ -13,7 +13,7 @@ resource "aws_lb" "external" {
     prefix  = "${var.lb_external_access_log_prefix}"
   }
 
-  tags = "${var.tags}"
+  tags = "${merge(var.tags, map("Name", var.external_lb_name))}"
 }
 
 resource "aws_security_group" "external_lb" {
@@ -127,7 +127,7 @@ resource "aws_lb_listener" "https_external" {
 }
 
 resource "aws_lb_target_group" "external" {
-  name                 = "${var.external_lb_name}-traefik"
+  name_prefix          = "tfk"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
@@ -146,6 +146,12 @@ resource "aws_lb_target_group" "external" {
   stickiness {
     enabled = true
     type    = "lb_cookie"
+  }
+
+  tags = "${merge(var.tags, map("Name", format("%s-traefik", var.external_lb_name)))}"
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/modules/traefik/internal.tf
+++ b/modules/traefik/internal.tf
@@ -14,7 +14,7 @@ resource "aws_lb" "internal" {
     prefix  = "${var.lb_internal_access_log_prefix}"
   }
 
-  tags = "${var.tags}"
+  tags = "${merge(var.tags, map("Name", var.internal_lb_name))}"
 }
 
 resource "aws_security_group" "internal_lb" {
@@ -98,7 +98,7 @@ resource "aws_security_group_rule" "nomad_client_internal_health_check" {
 #####################
 
 resource "aws_lb_target_group" "internal" {
-  name                 = "${var.internal_lb_name}-traefik"
+  name_prefix          = "tfk-i"
   port                 = "81"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
@@ -117,6 +117,12 @@ resource "aws_lb_target_group" "internal" {
   stickiness {
     enabled = true
     type    = "lb_cookie"
+  }
+
+  tags = "${merge(var.tags, map("Name", format("%s-traefik-internal", var.internal_lb_name)))}"
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
Prevents errors when the target groups need to be recreated.

e.g.

```

* aws_lb_target_group.external: Error deleting Target Group: ResourceInUse: Target group 'arn:aws:elasticloadbalancing:ap-southeast-1:xxx:targetgroup/external-traefik/xxx' is currently in use by a listener or a rule
	status code: 400, request id:xxx


```