### PR TITLE
Fix Consul DNS Race Condition

### DIFF
--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -4,3 +4,5 @@ consul_module_repo: "https://github.com/hashicorp/terraform-aws-consul.git"
 consul_version: "1.2.3"
 consul_enable_syslog: true
 consul_client_address: "0.0.0.0"
+
+dns_max_stale: "5s"

--- a/roles/consul/files/templates/dns_config.hcl
+++ b/roles/consul/files/templates/dns_config.hcl
@@ -1,0 +1,4 @@
+dns_config {
+  allow_stale = true
+  max_stale = "{{ dns_max_stale }}"
+}

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -109,4 +109,5 @@
   with_items:
   - syslog.hcl
   - override.hcl
+  - dns_config.hcl
   become: yes

--- a/roles/install-consul-template/files/run-consul-template.sh
+++ b/roles/install-consul-template/files/run-consul-template.sh
@@ -181,7 +181,8 @@ function request_vault_token {
 
   local token
   token=$(
-    curl -Ss -XPOST "${address}/v1/auth/${auth_path}login" \
+    curl -Ss -XPOST --retry 5 \
+      "${address}/v1/auth/${auth_path}login" \
       -d '{ "role": "'"${token_role}"'", "pkcs7": "'"${ec2_identity}"'" }'
   ) || exit $?
 


### PR DESCRIPTION
c.f. https://www.consul.io/docs/guides/dns-cache.html

By default, Consul allows servers to return stale DNS records up to a default stale age of 10 years (basically infinity). This allows all non-leader Consul nodes to service DNS queries.

Usually, this is not an issue. The Raft state between the servers are updated in the order of milliseconds according to Hashicorp. 

This causes a problem in this particular scenario:

- A fresh new Consul __server__ joins the cluster and starts syncing the cluster Raft state
- A DNS query is made while the state is being synced, resulting in potentially stale results from the DNS query

This happens in our case when the `consul-template` script is attempting to authenticate with vault on `vault.service.consul`. This results in intermittent failure.