### PR TITLE
Fix Prometheus Regex with relabelling

### DIFF
--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -49,9 +49,12 @@ In addition, you can add the following [tags](https://www.consul.io/docs/agent/s
 the form of `<key>=<value>` to change the behaviour for scraping:
 
 - `prometheus_path`: Change the path for scraping to anything else other than `/metrics`.
+- `prometheus_disable`: Set this to `true` to temporarily stop scraping this target
 
-Any other keys that are prefixed with `prometheus_` will be added as labels for the target with
-their prefixes removed.
+Up to 5 other keys that are prefixed with `prometheus_tag_` will be added as labels for the target
+with their prefixes removed. To allow for more tags, modify the the
+[Ansible playbook](packer/ami/site.yml) with more relabel actions. This is a limitation of
+Prometheus.
 
 ## Important Variables
 

--- a/modules/prometheus/packer/ami/site.yml
+++ b/modules/prometheus/packer/ami/site.yml
@@ -85,10 +85,38 @@
             replacement: '${1}'
             target_label: __metrics_path__
           - source_labels: ["__meta_consul_tags"]
+            regex: .*,prometheus_disable=true,.*
+            action: drop
+          # Convert all the `prometheus_tag_xxx` tags to additional tags for the target
+          # Due to how the regex works, we have to have as many actions as the number of potential
+          # tags
+          # See https://www.robustperception.io/extracting-full-labels-from-consul-tags
+          - source_labels: ["__meta_consul_tags"]
             action: replace
-            regex: .*,prometheus_([^,=]+)=([^,]+),.*
+            regex: ',(?:[^,]+,){0}prometheus_tag_([^=]+)=([^,]+),.*'
             replacement: '${2}'
             target_label: '${1}'
+          - source_labels: ["__meta_consul_tags"]
+            action: replace
+            regex: ',(?:[^,]+,){1}prometheus_tag_([^=]+)=([^,]+),.*'
+            replacement: '${2}'
+            target_label: '${1}'
+          - source_labels: ["__meta_consul_tags"]
+            action: replace
+            regex: ',(?:[^,]+,){2}prometheus_tag_([^=]+)=([^,]+),.*'
+            replacement: '${2}'
+            target_label: '${1}'
+          - source_labels: ["__meta_consul_tags"]
+            action: replace
+            regex: ',(?:[^,]+,){3}prometheus_tag_([^=]+)=([^,]+),.*'
+            replacement: '${2}'
+            target_label: '${1}'
+          - source_labels: ["__meta_consul_tags"]
+            action: replace
+            regex: ',(?:[^,]+,){4}prometheus_tag_([^=]+)=([^,]+),.*'
+            replacement: '${2}'
+            target_label: '${1}'
+
   - name: Stop Prometheus Service for the rest of the build
     systemd:
       name: prometheus

--- a/roles/telegraf/files/run-telegraf.sh
+++ b/roles/telegraf/files/run-telegraf.sh
@@ -236,7 +236,7 @@ service {
   port = ${prometheus_port}
 
   tags = [
-    "prometheus_server_type=${server_type}",
+    "prometheus_tag_server_type=${server_type}",
   ]
 
   check {


### PR DESCRIPTION
Otherwise only the final tag is ever matched on the original regex.

Cannot create multiple labels even if multiple groups are matched.