### PR TITLE
Add upgrade script for Consul, Nomad server and Vault

### DIFF
--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -309,7 +309,7 @@ clarity in the quorum values.
 You may choose to run the Python 3 `upgrade.py` script, which should not require additional
 dependency installation, to upgrade the instances.
 
-Currently only `consul` and `nomad-server` services can be done in this way.
+Currently only `consul`, `nomad-server` and `vault` services can be done in this way.
 
 Before you run the upgrade script, make sure to have your AWS credentials (such as env vars) set up
 correctly, to point to the right environment for the instance upgrade.
@@ -329,6 +329,12 @@ For `nomad-server`, the command should look like this:
 
 ```bash
 ./upgrade.py nomad-server --nomad-addr https://nomad.x.y
+```
+
+For `vault`, the command should look like this (run within your environment directory):
+
+```bash
+./upgrade.py vault --vault-ca-cert "$(git rev-parse --show-toplevel)/environments/xxx/ca/root/ca.pem"
 ```
 
 For more information, run

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -312,12 +312,19 @@ dependency installation, to upgrade the instances.
 Currently only `consul`, `nomad-server` and `vault` services can be done in this way.
 
 Before you run the upgrade script, make sure to have your AWS credentials (such as env vars) set up
-correctly, to point to the right environment for the instance upgrade.
+correctly, to point to the right environment for the instance upgrade. You may also choose to
+supply the environment variables while running the script, e.g.
+`AWS_PROFILE=staging ./upgrade.py ...`.
 
-The script will terminate the max number of instances within the quorum (i.e. number of instances
-of that service type left would still be in quorum), checking that the new instances are up and
-correctly connected to their respective servies, before continuing to repeat the process, until
-all old instances in that service type have been terminated and upgraded with new ones.
+The script will terminate every instance type one-by-one, which is the safest way to maintain
+quorum in each of the service type. Additionally, the script will check that the new instance is up
+and correctly connected to its respective service, before continuing with the upgrade process,
+until all old instances in that service type have been terminated and upgraded with new ones.
+
+A fast (and furious) mode has also been added to the script, which can be turned on with the flag
+`--fast`. In this mode, the script will calculate the maximum number of instances to terminate
+at runtime for the specified service, while still maintaining quorum even if the new instances
+are unable to start up properly. Please take precaution when using this mode.
 
 For `consul`, the command should look like this:
 
@@ -331,10 +338,12 @@ For `nomad-server`, the command should look like this:
 ./upgrade.py nomad-server --nomad-addr https://nomad.x.y
 ```
 
-For `vault`, the command should look like this (run within your environment directory):
+For `vault`, the command should look like this:
 
 ```bash
-./upgrade.py vault --vault-ca-cert "$(git rev-parse --show-toplevel)/environments/xxx/ca/root/ca.pem"
+./upgrade.py vault \
+    --consul-addr https://consul.x.y \
+    --vault-ca-cert /path/to/environments/xxx/ca.pem"
 ```
 
 For more information, run

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -26,7 +26,7 @@ NOMAD_ADDR = 'http://127.0.0.1:4646'
 
 # Vault defaults
 VAULT_USERNAME = 'ubuntu'
-VAULT_TLS_SERVER = 'vault.consul.service'
+VAULT_TLS_SERVER = 'vault.service.consul'
 VAULT_PORT = 8200
 VAULT_CONSUL_SERVICE_NAME = 'vault'
 VAULT_UNSEAL_COUNT = 3  # Default number of unseals required
@@ -505,7 +505,7 @@ if __name__ == '__main__':
     parser.add_argument('--vault-tag', default=VAULT_TAG,
                         help='Tag pattern of Vault instances. Defaults to "{}".'.format(VAULT_TAG))
     parser.add_argument('--vault-tls-server', default=VAULT_TLS_SERVER,
-                        help='TLS server to point to when connecting to the Vault server via TLS. Defaults to "{}"'.format(VAULT_TLS_SERVER))
+                        help='TLS server to point to when connecting to the Vault server via TLS. Defaults to "{}".'.format(VAULT_TLS_SERVER))
     parser.add_argument('--vault-ca-cert',
                         help='Path to CA certificate on this host machine for unsealing')
     parser.add_argument('--vault-port', default=VAULT_PORT,

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -172,7 +172,7 @@ def get_instance_ip_addr_from_id(id):
 
 
 def get_instance_ip_addrs_from_ids(ids):
-    map(get_instance_ip_addr_from_id, ids)
+    return map(get_instance_ip_addr_from_id, ids)
 
 
 def get_new_instances_from_prev(prev_instances, curr_instances):
@@ -300,7 +300,7 @@ def list_vault_members():
 
 
 def send_and_unseal_vault(new_instances, username, local_ca_cert_path, remote_ca_cert_dir, vault_local_addr, unseal_keys):
-    new_ip_addrs = get_instance_ip_addr_from_id(new_instances)
+    new_ip_addrs = get_instance_ip_addrs_from_ids(new_instances)
 
     for new_ip_addr in new_ip_addrs:
         send_ca_cert(username, new_ip_addr,

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -431,7 +431,7 @@ def upgrade_vault(vault_tag_pattern, username, local_ca_cert_path, remote_ca_cer
     aws_instances = get_instance_ids_from_tag(vault_tag_pattern)
     vault_servers = list_vault_members()
     print('AWS instances: {}'.format(aws_instances))
-    print('Nomad servers: {}'.format(vault_servers))
+    print('Vault servers: {}'.format(vault_servers))
     assert_same_instances(aws_instances, vault_servers)
 
     n = find_n_to_kill_in_quorum(aws_instances)

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -66,7 +66,8 @@ def assert_arg(flag, arg):
 
 def assert_collection_len(collection, length):
     if len(collection) != length:
-        sys.exit('Collection "{}" does not have expected length {}!'.format(collection, length))
+        sys.exit('Collection "{}" does not have expected length {}!'.format(
+            collection, length))
 
 
 def assert_file_exists(path):
@@ -93,11 +94,12 @@ def assert_same_instances(aws_instances, service_nodes):
 # Can be used to swap out kill_fn
 def fake_kill_fn(aws_instance):
     print('Fake killing instance "{}"'.format(aws_instance))
-    
+
 
 # Can be used to swap out check_fn
 def fake_check_fn(prev_instances, killing_idx):
-    print('Fake checking {} at killing index {}'.format(prev_instances, killing_idx))
+    print('Fake checking {} at killing index {}'.format(
+        prev_instances, killing_idx))
     return True
 
 
@@ -108,6 +110,7 @@ def fake_get_new_instances(prev_instances, curr_instances):
 #
 # General
 #
+
 
 def unique(seq):
     # Inefficient but works
@@ -209,7 +212,6 @@ def check_service_up(prev_aws_instances, killing_idx, n, tag_pattern, get_servic
     # We assume that prev_aws_instances contain the same number of entries as
     # the original
     instance_count = len(prev_aws_instances)
-
     curr_aws_instances = get_instance_ids_from_tag(tag_pattern)
 
     # Cater for remaining instances when the count is less than N
@@ -244,7 +246,8 @@ def kill_check_post(kill_fn, check_fn, post_fn, tag_pattern, n, check_interval, 
                     'New instance(s) is/are unable to join the service after timeout of {}s, aborting...'.format(timeout.total_seconds()))
 
             curr_instances = get_instance_ids_from_tag(tag_pattern)
-            new_instances = get_new_instances_fn(prev_aws_instances, curr_instances)
+            new_instances = get_new_instances_fn(
+                prev_aws_instances, curr_instances)
 
             print('New instance(s) found: {}'.format(new_instances))
 
@@ -361,10 +364,11 @@ def upgrade_consul(consul_tag_pattern, address, check_interval, timeout):
     assert_n_quorum(n)
 
     def check_fn(prev_aws_instances, idx):
-        check_service_up(prev_aws_instances, idx, n,
-                         consul_tag_pattern, lambda: list_consul_peers(address))
+        return check_service_up(prev_aws_instances, idx, n,
+                                consul_tag_pattern, lambda: list_consul_peers(address))
 
     def post_fn(new_instances):
+        # Do nothing
         pass
 
     kill_check_post(
@@ -391,10 +395,11 @@ def upgrade_nomad_server(nomad_server_tag_pattern, address, check_interval, time
     assert_n_quorum(n)
 
     def check_fn(prev_aws_instances, idx):
-        check_service_up(prev_aws_instances, idx, n, nomad_server_tag_pattern,
-                         lambda: list_nomad_server_members(address))
+        return check_service_up(prev_aws_instances, idx, n, nomad_server_tag_pattern,
+                                lambda: list_nomad_server_members(address))
 
     def post_fn(new_instances):
+        # Do nothing
         pass
 
     kill_check_post(
@@ -433,8 +438,8 @@ def upgrade_vault(vault_tag_pattern, username, local_ca_cert_path, remote_ca_cer
     assert_n_quorum(n)
 
     def check_fn(prev_aws_instances, idx):
-        check_service_up(prev_aws_instances, idx, n, vault_tag_pattern,
-                         list_vault_members)
+        return check_service_up(prev_aws_instances, idx, n, vault_tag_pattern,
+                                list_vault_members)
 
     def post_fn(new_instances):
         send_and_unseal_vault(new_instances, username, local_ca_cert_path,

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -305,6 +305,7 @@ def list_vault_members():
 
 def send_and_unseal_vault(new_instances, username, local_ca_cert_path, remote_ca_cert_dir, vault_local_addr, unseal_keys):
     new_ip_addrs = get_instance_ip_addrs_from_ids(new_instances)
+    print('Unsealing Vault servers at {}'.format(new_ip_addrs))
 
     for new_ip_addr in new_ip_addrs:
         send_ca_cert(username, new_ip_addr,

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -80,7 +80,9 @@ def unique(seq):
 def find_n_to_kill_in_quorum(instances):
     # The number of instances left must be simple majority to maintain quorum
     # https://www.consul.io/docs/internals/consensus.html#deployment-table
-    return int(max((len(instances) + 1) / 2 - 1, 0))
+    # Be careful with numeric operations in Python, since they are by default
+    # interpreted as floating points operations
+    return int(max(math.floor((len(instances) + 1) / 2) - 1, 0))
 
 
 def invoke_shell(cmd):

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -273,7 +273,7 @@ def upgrade_consul(consul_tag_pattern, address, check_interval, timeout):
     n = find_n_to_kill_in_quorum(aws_instances)
     assert_n_quorum(n)
 
-    checker = lambda prev_aws_instances, idx: \
+    def checker(prev_aws_instances, idx):
         consul_nomad_server_checker(prev_aws_instances, idx, n, consul_tag_pattern, lambda: list_consul_peers(address))
 
     execute_kill_loop(
@@ -298,7 +298,7 @@ def upgrade_nomad_server(nomad_server_tag_pattern, address, check_interval, time
     n = find_n_to_kill_in_quorum(aws_instances)
     assert_n_quorum(n)
     
-    checker = lambda prev_aws_instances, idx: \
+    def checker(prev_aws_instances, idx):
         consul_nomad_server_checker(prev_aws_instances, idx, n, nomad_server_tag_pattern, lambda: list_nomad_server_members(address))
 
     execute_kill_loop(
@@ -332,6 +332,18 @@ def upgrade_vault(vault_tag_pattern, unseal_count, ca_cert_path, check_interval,
 
     n = find_n_to_kill_in_quorum(aws_instances)
     assert_n_quorum(n)
+
+    def checker(prev_aws_instances, idx):
+        # consul_nomad_server_checker(prev_aws_instances, idx, n, vault_tag_pattern, lambda: list_nomad_server_members(address))
+        pass
+
+    # execute_kill_loop(
+    #     kill_instance,
+    #     vault_tag_pattern,
+    #     checker,
+    #     n,
+    #     check_interval,
+    #     timeout)
 
 #
 # Main

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+from datetime import timedelta
+import math
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+#
+# Constants
+#
+
+# ASG prefixes to grep
+CONSUL_ASG = 'consul'
+NOMAD_SERVER_ASG = 'nomad-server'
+NOMAD_CLIENT_ASG = 'nomad-client'
+VAULT_ASG = 'vault'
+
+# Default addresses
+CONSUL_ADDR = 'http://127.0.0.1:8500'
+NOMAD_ADDR = 'http://127.0.0.1:4646'
+VAULT_ADDR = 'https://127.0.0.1:8200'
+
+# Interval of checking the change in set entries
+CHECK_INTERVAL_SECS = 5
+
+# Max time value to allow for ensuring both AWS and services have same set after killing
+TIMEOUT_SECS = 300
+
+# Commands to ensure to be available before starting
+CMDS = [
+    'aws',
+    'consul',
+    'nomad',
+    'jq'
+]
+
+#
+# Assertion commands
+#
+
+def assert_environ(env_name):
+    env = os.environ.get(env_name)
+    if not env:
+        sys.exit('Require env var "{}" to be set!'.format(env_name))
+
+    return env
+
+def assert_cmds_exist(cmds):
+    for cmd in cmds:
+        if not shutil.which(cmd):
+            sys.exit('Require command "{}"!'.format(cmd))
+
+
+def assert_same_instances(aws_instances, service_nodes):
+    if not aws_instances == service_nodes:
+        sys.exit('AWS set of instances: "{}" is different from current set of service nodes: "{}"! Aborting...'
+            .format(aws_instances, service_nodes))
+
+#
+# General
+#
+
+def unique(seq):
+    # Inefficient but works
+    # http://www.martinbroadhurst.com/removing-duplicates-from-a-list-while-preserving-order-in-python.html
+    seen = set()
+    return [x for x in seq if not (x in seen or seen.add(x))]
+
+
+def find_max_n_to_kill(instances):
+    # Find the max N instances that can terminate in one go
+    # Min is still 1, cannot be 0
+    return max(math.floor(len(instances) / 2), 1)
+
+
+def invoke_shell(cmd):
+    return subprocess.check_output(cmd, shell=True).decode('ascii').strip()
+
+
+def get_auto_scaling_name(grep_name):
+    try:
+        return invoke_shell("""
+        aws autoscaling describe-auto-scaling-groups | \
+            jq --raw-output \
+                '.AutoScalingGroups | .[] | .AutoScalingGroupName' | grep {}
+        """.format(grep_name))
+    except:
+        raise AssertionError('"{}" prefixed ASG name does not exist!'.format(grep_name))
+
+
+def get_instances_from_asg(asg_name):
+    try:
+        return set(invoke_shell("""
+        aws autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-name {} | \
+            jq --raw-output '.AutoScalingGroups[0].Instances[].InstanceId'
+        """.format(asg_name)).split())
+    except:
+        raise AssertionError('Cannot find instances from "{}" ASG!'.format(asg_name))
+
+
+def kill_instance_from_asg(aws_instance):
+    try:
+        invoke_shell("""
+        aws autoscaling terminate-instance-in-auto-scaling-group \
+            --no-should-decrement-desired-capacity \
+            --instance-id {}
+        """.format(aws_instance))
+    except:
+        raise AssertionError('Unable to terminate AWS instance "{}" from its ASG!'
+            .format(aws_instance))
+
+
+def try_until_timeout(predicate, check_interval, timeout):
+    elapsed_time = timedelta(seconds=0)
+
+    while True:
+        if predicate():
+            return True
+
+        if elapsed_time >= timeout:
+            return False
+
+        wait_secs = check_interval.total_seconds()
+        print('> Waiting for {}s ({}s has elapsed)'.format(wait_secs, elapsed_time.total_seconds()))
+        time.sleep(wait_secs)
+        elapsed_time += check_interval
+
+
+def execute_kill_loop(kill_fn, asg_name, get_service_nodes_fn, n, check_interval, timeout):
+    print("Killing {} instance(s) in one go...".format(n))
+
+    orig_aws_instances = get_instances_from_asg(asg_name)
+    instance_count = len(orig_aws_instances)
+
+    for idx, orig_aws_instance in enumerate(orig_aws_instances):
+        prev_aws_instances = get_instances_from_asg(asg_name)
+
+        print('Killing instance "{} ({}/{})"...'.format(orig_aws_instance, idx + 1, instance_count))
+        kill_fn(orig_aws_instance)
+
+        # Check only after every N kills
+        if (idx + 1) % n == 0 or (idx + 1) == instance_count:
+            def predicate():
+                curr_aws_instances = get_instances_from_asg(asg_name)
+                curr_service_nodes = get_service_nodes_fn()
+
+                # Cater for remaining instances when the count is less than N
+                wait_n = min(instance_count - idx, n)
+
+                return \
+                    len(orig_aws_instances) == len(curr_aws_instances) and \
+                    len(curr_aws_instances.difference(prev_aws_instances)) == wait_n and \
+                    curr_aws_instances == curr_service_nodes
+
+            print('KILL okay! Waiting for new instance(s) to spin up...')
+
+            if not try_until_timeout(predicate, check_interval, timeout):
+                raise AssertionError(
+                    'New instance(s) is/are unable to join the service after timeout of {}s, aborting...'.format(timeout.total_seconds()))
+            
+            new_instances = get_instances_from_asg(asg_name).difference(prev_aws_instances)
+            print('New instance(s) found: {}', format(new_instances))
+
+#
+# Consul specifics
+#
+
+def list_consul_peers(address):
+    try:
+        return set(invoke_shell("""
+        consul operator raft list-peers --http-addr {} | \
+            grep -E i-[0-9a-f]+ | \
+            cut -d " " -f 1
+        """.format(address)).split())
+    except:
+        raise AssertionError('Unable to obtain peers from Consul operator raft list from "{}"!'
+            .format(address))
+
+#
+# Nomad Server specifics
+#
+
+def list_nomad_server_members(address):
+    try:
+        return set(invoke_shell(r"""
+        nomad server members -address {} | grep alive | sed -E 's/^(i-[0-9a-f]+)\..+$/\1/'
+        """.format(address)).split())
+    except:
+        raise AssertionError('Unable to obtain Nomad Server members from "{}"!'
+            .format(address))
+
+#
+# High level
+#
+
+def upgrade_consul(consul_asg, address, check_interval, timeout):
+    print("Upgrading Consul instances...")
+    consul_asg = get_auto_scaling_name(consul_asg)
+
+    # Sanity check
+    aws_instances = get_instances_from_asg(consul_asg)
+    consul_nodes = list_consul_peers(address)
+    print('AWS instances: {}'.format(aws_instances))
+    print(' Consul nodes: {}'.format(consul_nodes))
+    assert_same_instances(aws_instances, consul_nodes)
+
+    n = find_max_n_to_kill(aws_instances)
+    
+    execute_kill_loop(
+        kill_instance_from_asg,
+        consul_asg,
+        lambda: list_consul_peers(address),
+        n,
+        check_interval,
+        timeout)
+
+
+def upgrade_nomad_server(nomad_server_asg, address, check_interval, timeout):
+    print("Upgrading Nomad Servers instances...")
+    nomad_server_asg = get_auto_scaling_name(nomad_server_asg)
+
+    # Sanity check
+    aws_instances = get_instances_from_asg(nomad_server_asg)
+    nomad_servers = list_nomad_server_members(address)
+    print('AWS instances: {}'.format(aws_instances))
+    print('Nomad servers: {}'.format(nomad_servers))
+    assert_same_instances(aws_instances, nomad_servers)
+
+    n = find_max_n_to_kill(aws_instances)
+    
+    execute_kill_loop(
+        kill_instance_from_asg,
+        nomad_server_asg,
+        lambda: list_nomad_server_members(address),
+        n,
+        check_interval,
+        timeout)
+
+
+# TODO - Need to figure out how to properly wait for all upgradeed allocs get
+#        reallocated first synchronously
+# def upgrade_nomad_client(nomad_client_asg, address, check_interval, timeout):
+#     nomad_client_asg = get_auto_scaling_name(nomad_client_asg)
+
+# TODO - Need to make it such that we can place N unsealing keys into an env var
+#        and let it automatically unseal using the env var iteratively
+# def upgrade_vault(vault_asg, address, check_interval, timeout):
+#     vault_asg = get_auto_scaling_name(vault_asg)
+
+#
+# Main
+#
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Script to upgrade service instances')
+
+    # Dashes get converted into underscore when accessing the fields
+    parser.add_argument('service', nargs='+', help='Service type to upgrade. consul | nomad-server | nomad-client | vault')
+
+    parser.add_argument('--consul-asg', default=CONSUL_ASG, help='Simple grep pattern to get Consul ASG. Defaults to "{}".'.format(CONSUL_ASG))
+    parser.add_argument('--consul-addr', default=CONSUL_ADDR, help='Consul server address to connect to. Defaults to "{}".'.format(CONSUL_ADDR))
+
+    parser.add_argument('--nomad-server-asg', default=NOMAD_SERVER_ASG, help='Simple grep pattern to get Nomad Server ASG. Defaults to "{}".'.format(NOMAD_SERVER_ASG))
+    parser.add_argument('--nomad-client-asg', default=NOMAD_CLIENT_ASG, help='Simple grep pattern to get Nomad Client ASG. Defaults to "{}".'.format(NOMAD_CLIENT_ASG))
+    parser.add_argument('--nomad-addr', default=NOMAD_ADDR, help='Nomad Server address to connect to. Defaults to "{}".'.format(NOMAD_ADDR))
+
+    parser.add_argument('--vault-asg', default=VAULT_ASG, help='Simple grep pattern to get Vault ASG. Defaults to "{}".'.format(VAULT_ASG))
+    parser.add_argument('--vault-addr', default=VAULT_ADDR, help='Vault server address to connect to. Defaults to "{}".'.format(VAULT_ADDR))
+
+    parser.add_argument('--check-interval', type=int, default=CHECK_INTERVAL_SECS, help='Interval of checking success for every upgrade step. Defaults to "{}" seconds.'.format(CHECK_INTERVAL_SECS))
+    parser.add_argument('--timeout', type=int, default=TIMEOUT_SECS, help='Max time value to allow for ensuring consistency in upgrade after killing. Defaults to "{}" seconds.'.format(TIMEOUT_SECS))
+
+    args = parser.parse_args()
+
+    services = unique(args.service)
+    check_interval = timedelta(seconds=args.check_interval)
+    timeout = timedelta(seconds=args.timeout)
+
+    print('Services to upgrade (in order): {}'.format(services))
+
+    assert_cmds_exist(CMDS)
+
+    for service in services:
+        # All environment addresses should not contain trailing slash
+        # e.g. http://consul.x.y OR https://consul.x.y
+        if service == 'consul':
+            upgrade_consul(args.consul_asg, args.consul_addr, check_interval, timeout)
+            print('DONE Consul upgrading!')
+        elif service == 'nomad-server':
+            upgrade_nomad_server(args.nomad_server_asg, args.nomad_addr, check_interval, timeout)
+            print('DONE Nomad Server upgrading!')
+        elif service == 'nomad-client':
+            # TODO
+            # upgrade_nomad_client(args.nomad_client_asg, args.nomad_addr, check_interval, timeout)
+            print('DONE Nomad Client upgrading!')
+        elif service == 'vault':
+            # TODO
+            # upgrade_vault(args.vault_asg, args.vault_addr, check_interval, timeout)
+            print('DONE Vault upgrading!')
+        else:
+            print('Ignoring unknown command "{}"'.format(service))
+    
+    print("DONE!")

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -105,7 +105,9 @@ def get_instances_from_asg(asg_name):
         return set(invoke_shell("""
         aws autoscaling describe-auto-scaling-groups \
             --auto-scaling-group-name {} | \
-            jq --raw-output '.AutoScalingGroups[0].Instances[].InstanceId'
+            jq --raw-output '.AutoScalingGroups[0].Instances[] |
+                select(.LifecycleState | contains("InService")) |
+                .InstanceId'
         """.format(asg_name)).split())
     except:
         raise AssertionError('Cannot find instances from "{}" ASG!'.format(asg_name))

--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -94,7 +94,7 @@ def get_auto_scaling_name(grep_name):
         return invoke_shell("""
         aws autoscaling describe-auto-scaling-groups | \
             jq --raw-output \
-                '.AutoScalingGroups | .[] | .AutoScalingGroupName' | grep {}
+                '.AutoScalingGroups | .[].AutoScalingGroupName' | grep {}
         """.format(grep_name))
     except:
         raise AssertionError('"{}" prefixed ASG name does not exist!'.format(grep_name))


### PR DESCRIPTION
Supersedes #212.

Works for consul, nomad-server and vault.

Basically it terminates N - simple_majority(N) each time, and then check that the new instances are able to connect back to their respective services (by checking the set of AWS instances and service specific instances to be the same), before continuing.

For Vault, it prompts for unseal keys at the start, and automatically unseals and checks seal status for you (need to provide CA cert).