### PR TITLE
Bump Min Packer Version for Prometheus Data AMI

### DIFF
--- a/modules/prometheus/packer/data/packer.json
+++ b/modules/prometheus/packer/data/packer.json
@@ -1,6 +1,6 @@
 {
     "description": "Create and format an EBS volume for Prometheus data",
-    "min_packer_version": "1.1.2",
+    "min_packer_version": "1.3.4",
     "variables": {
         "volume_name": "prometheus-server-data",
         "aws_region": "ap-southeast-1",


### PR DESCRIPTION
Includes https://github.com/hashicorp/packer/pull/7059

Currently unreleased. But good to include this fix in.

If you want to build the image now, use the build from this [comment](https://github.com/hashicorp/packer/issues/6965#issuecomment-443047963) or manually hardcode a volume size in the Packer template.