### PR TITLE
Update fluentd template for 2.0.0

### DIFF
--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -42,7 +42,7 @@
     s3_region "${s3_region}"
 
     path "${s3_prefix}%Y/%m/%d/%H/$${tag}/"
-    s3_object_key_format "%{path}%{time_slice}_%{hex_random}_%{index}.%{file_extension}"
+    s3_object_key_format "%%{path}%%{time_slice}_%%{hex_random}_%%{index}.%%{file_extension}"
     buffer_path "buffer/"
     storage_class "${storage_class}"
 


### PR DESCRIPTION
Recent change in provider template https://github.com/terraform-providers/terraform-provider-template/blob/master/CHANGELOG.md#200-january-14-2019 causes 
```
s3_object_key_format "%{path}%{time_slice}_%{hex_random}_%{index}.%{file_extension}"
```
to break