### PR TITLE
Pin fluentd template provider min version

### DIFF
--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -1,3 +1,7 @@
+provider "template" {
+  version = "~> 2.0"
+}
+
 data "template_file" "fluentd_tf_rendered_conf" {
   template = "${file("${path.module}/templates/fluent.conf")}"
 

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -1,4 +1,6 @@
 provider "template" {
+  # See: https://github.com/terraform-providers/terraform-provider-template/blob/v2.0.0/CHANGELOG.md#200-january-14-2019
+  # Need to pin the minimum version for templates/fluent.conf
   version = "~> 2.0"
 }
 


### PR DESCRIPTION
Following #223, this provides a slightly better assurance that the user is using the right version of `template` provider.

Tested for the following cases:
### 1. "Overriding" from user code with another `provider "template"` with non-overlapping condition:
```hcl
provider "template" {
  version = "~> 1.0"
}
```
gives
```txt
No provider "template" plugins meet the constraint "~> 1.0,~> 2.0".

The version constraint is derived from the "version" argument within the
provider "template" block in configuration. Child modules may also apply
provider version constraints. To view the provider versions requested by each
module in the current configuration, run "terraform providers".
```

###  2. "Overriding" from user code with another `provider "template"` with overlapping condition:
```hcl
provider "template" {
  version = ">= 1.0, <= 3.0"
}
```
or can also use
```hcl
provider "template" {
  version = "~> 2.0"
}
```
gives
```txt
...
Terraform has been successfully initialized!
```

So the pinning still provides sufficient flexibility at the user code site.