### PR TITLE
Allow core to forward docker_privileged flag

### DIFF
--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -31,6 +31,8 @@ module "nomad_clients" {
   cluster_tag_key     = "${var.cluster_tag_key}"
   consul_cluster_name = "${var.consul_cluster_name}"
 
+  docker_privileged = "${var.nomad_clients_docker_privileged}"
+
   integration_consul_prefix = "${var.integration_consul_prefix}"
   integration_service_type  = "nomad_client"
 

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -209,6 +209,11 @@ variable "nomad_servers_user_data" {
   default = ""
 }
 
+variable "nomad_clients_docker_privileged" {
+  description = "Flag to enable privileged mode for Docker agent on Nomad client"
+  default     = false
+}
+
 variable "nomad_clients_user_data" {
   # See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
   # The default is at user_data/user-data-nomad-client.sh


### PR DESCRIPTION
So that `core` can also override this flag if required.