### PR TITLE
Update netshare version

### DIFF
--- a/modules/core/packer/nomad_clients/packer.json
+++ b/modules/core/packer/nomad_clients/packer.json
@@ -26,7 +26,7 @@
         "consul_scheme": "https",
         "consul_token": "",
         "consul_integration_prefix": "terraform/",
-        "netshare_version": "0.35",
+        "netshare_version": "0.36",
         "docker_enable_efs": "false",
         "timezone": "Asia/Singapore",
         "extra_vars": "{}"

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -23,7 +23,7 @@
     consul_token: ""
     consul_integration_prefix: "terraform/"
     nomad_additional_config: []
-    netshare_version: 0.35
+    netshare_version: 0.36
     docker_enable_efs: false
     timezone: "Asia/Singapore"
   tasks:


### PR DESCRIPTION
Basically a more stable Docker volume driver:
- https://github.com/ContainX/docker-volume-netshare/releases/tag/v0.36
- https://github.com/ContainX/docker-volume-netshare/pull/163