### PR TITLE
Add AWS ECR module

### DIFF
--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -6,9 +6,14 @@ Provides an EC2 Container Registry Repository.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws\_region | AWS Region to deploy to | string | `"ap-southeast-1"` | no |
-| ecr\_name | Name of AWS EC2 Container Registry repository | string | `"locus"` | no |
-| s3\_state\_bucket | S3 Bucket storing Terraform state | string | n/a | yes |
+| add\_route53\_record | Flag to state whether to add additional A record into Route53 | string | `"true"` | no |
+| lb\_cname | DNS CNAME for the Load balancer. Only applicable if `add_route53_record` is `true` | string | `""` | no |
+| lb\_zone\_id | Zone ID for the Load balancer DNS CNAME. Only applicable if `add_route53_record` is `true` | string | `""` | no |
+| name | Name of AWS EC2 Container Registry repository | string | n/a | yes |
+| redirect\_listener\_arn | LB listener ARN to attach the rule to. Only applicable if `add_route53_record` is `true` | string | `""` | no |
+| redirect\_rule\_priority | Rule priority for redirect. Only applicable if `add_route53_record` is `true` | string | `"100"` | no |
+| route53\_domain | Domain to set as A record for Route53. Only applicable if `add_route53_record` is `true` | string | `""` | no |
+| route53\_zone\_id | Zone ID to use for Route53 record. Only applicable if `add_route53_record` is `true` | string | `""` | no |
 | tags | A map of tags to add to all resources | map | `<map>` | no |
 
 ## Outputs
@@ -19,3 +24,5 @@ Provides an EC2 Container Registry Repository.
 | name | Name of AWS EC2 Container Registry repository |
 | registry\_id | The registry ID where the repository was created |
 | repository\_url | The URL of the repository, in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName |
+| service\_url | The URL of the repository service, in the form aws_account_id.dkr.ecr.region.amazonaws.com |
+| subdomain | Subdomain domain of the A record |

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -2,6 +2,26 @@
 
 Provides an EC2 Container Registry Repository.
 
+## Example usage
+
+```hcl
+module "ecr" {
+  source = "/path/to/vendor/terraform-modules/modules/ecr"
+
+  name = "${var.ecr_name}"
+  tags = "${var.tags}"
+
+  add_route53_record = true
+  route53_zone_id    = "${var.route53_zone_id}"
+  route53_domain     = "mydocker"
+
+  lb_cname              = "${var.core_internal_lb_dns_name}"
+  lb_zone_id            = "${var.core_internal_lb_zone_id}"
+  redirect_listener_arn = "${var.core_internal_lb_https_listener_arn}"
+  redirect_rule_priority = 100
+}
+```
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -1,0 +1,21 @@
+# AWS EC2 Container Registry Repository
+
+Provides an EC2 Container Registry Repository.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| aws\_region | AWS Region to deploy to | string | `"ap-southeast-1"` | no |
+| ecr\_name | Name of AWS EC2 Container Registry repository | string | `"locus"` | no |
+| s3\_state\_bucket | S3 Bucket storing Terraform state | string | n/a | yes |
+| tags | A map of tags to add to all resources | map | `<map>` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| arn | Full ARN of AWS EC2 Container Registry repository |
+| name | Name of AWS EC2 Container Registry repository |
+| registry\_id | The registry ID where the repository was created |
+| repository\_url | The URL of the repository, in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName |

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,10 @@
+data "aws_region" "current" {}
+
+resource "aws_ecr_repository" "default" {
+  name = "${var.name}"
+  tags = "${var.tags}"
+}
+
+locals {
+  service_url = "${element(split("/", aws_ecr_repository.default.repository_url), 0)}"
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,29 @@
+output "name" {
+  description = "Name of AWS EC2 Container Registry repository"
+  value       = "${aws_ecr_repository.default.name}"
+}
+
+output "arn" {
+  description = "Full ARN of AWS EC2 Container Registry repository"
+  value       = "${aws_ecr_repository.default.arn}"
+}
+
+output "registry_id" {
+  description = "The registry ID where the repository was created"
+  value       = "${aws_ecr_repository.default.registry_id}"
+}
+
+output "repository_url" {
+  description = "The URL of the repository, in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName"
+  value       = "${aws_ecr_repository.default.repository_url}"
+}
+
+output "service_url" {
+  description = "The URL of the repository service, in the form aws_account_id.dkr.ecr.region.amazonaws.com"
+  value       = "${local.service_url}"
+}
+
+output "subdomain" {
+  description = "Subdomain domain of the A record"
+  value       = "${var.route53_domain}"
+}

--- a/modules/ecr/route53.tf
+++ b/modules/ecr/route53.tf
@@ -1,0 +1,35 @@
+resource "aws_route53_record" "redirect" {
+  count = "${var.add_route53_record ? 1 : 0}"
+
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.route53_domain}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.lb_cname}"
+    zone_id                = "${var.lb_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_lb_listener_rule" "redirect" {
+  count = "${var.add_route53_record ? 1 : 0}"
+
+  listener_arn = "${var.redirect_listener_arn}"
+  priority     = "${var.redirect_rule_priority}"
+
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "${local.service_url}"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${aws_route53_record.redirect.fqdn}"]
+  }
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,44 @@
+variable "name" {
+  description = "Name of AWS EC2 Container Registry repository"
+}
+
+variable "add_route53_record" {
+  description = "Flag to state whether to add additional A record into Route53"
+  default     = true
+}
+
+variable "route53_zone_id" {
+  description = "Zone ID to use for Route53 record. Only applicable if `add_route53_record` is `true`"
+}
+
+variable "route53_domain" {
+  description = "Domain to set as A record for Route53. Only applicable if `add_route53_record` is `true`"
+}
+
+variable "lb_cname" {
+  description = "DNS CNAME for the Load balancer. Only applicable if `add_route53_record` is `true`"
+  default     = ""
+}
+
+variable "lb_zone_id" {
+  description = "Zone ID for the Load balancer DNS CNAME. Only applicable if `add_route53_record` is `true`"
+  default     = ""
+}
+
+variable "redirect_listener_arn" {
+  description = "LB listener ARN to attach the rule to. Only applicable if `add_route53_record` is `true`"
+  default     = ""
+}
+
+variable "redirect_rule_priority" {
+  description = "Rule priority for redirect. Only applicable if `add_route53_record` is `true`"
+  default     = 100
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+
+  default {
+    Terraform = "true"
+  }
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -9,10 +9,12 @@ variable "add_route53_record" {
 
 variable "route53_zone_id" {
   description = "Zone ID to use for Route53 record. Only applicable if `add_route53_record` is `true`"
+  default     = ""
 }
 
 variable "route53_domain" {
   description = "Domain to set as A record for Route53. Only applicable if `add_route53_record` is `true`"
+  default     = ""
 }
 
 variable "lb_cname" {


### PR DESCRIPTION
Comes with redirect, but requires load balancer + listener, so that we can use nicer name in `docker push xxx.base.domain/repo/image:tag`.