### PR TITLE
chore(fluentd): root user

### DIFF
--- a/modules/fluentd/templates/fluentd.nomad
+++ b/modules/fluentd/templates/fluentd.nomad
@@ -50,7 +50,6 @@ job "fluentd" {
         volumes = [
           "${fluentd_conf_file}:/fluentd/etc/fluent.conf",
           "alloc/logs:/fluentd/logs:rw",
-          "alloc/buffer:/fluentd/buffer:rw",
           "secrets/config:/config/secrets",
           "alloc/additional:/config/additional",
         ]


### PR DESCRIPTION
`fluent` Docker image runs as non-root user as per Docker best practices:
https://github.com/fluent/fluentd-docker-image/issues/48

This means that this [line](https://github.com/dsaidgovsg/terraform-modules/blob/8b7590b64b4d019668bb67a146566261fb591e8e/modules/fluentd/templates/fluent.conf#L55) in the config will mount the directory as root and cause a permission error when trying to write to the buffer before flushing to S3.